### PR TITLE
Dev

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: Setup and run tests
+
+on:
+  push:
+    branches: [ "main", "dev"]
+  pull_request:
+    branches: [ "main", "dev" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        conda install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        conda install pytest
+        pytest -m "not local_only"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 **/*.pyc
+**/*.ipynb
 .vscode
 .env
 **/__pycache__

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently, it supports Metropolis-Hastings kernels:
 * Random walk Metropolis-Hastings (RWMH)
 * Metropolis adjusted Langevin algorithm (MALA)
 * Hamiltonian Monte Carlo (HMC)
+* No-U-turn sampler (NUTS)
 
 NFs can be used as preconditioners, as in the NeuTra MCMC framework (Hoffman et al., 2017).
 They can also be used as independent proposal distributions, as in IMH and Ex2 MCMC (Samsonov et al., 2022).
@@ -97,6 +98,11 @@ sample(..., kernel='ex2_hmc')   # HMC
 sample(..., kernel='neutra_rwmh')  # RWMH
 sample(..., kernel='neutra_mala')  # MALA
 sample(..., kernel='neutra_hmc')   # HMC
+
+# NUTS analogs
+sample(..., kernel='jump_nuts')
+sample(..., kernel='ex2_nuts')
+sample(..., kernel='neutra_nuts')
 ```
 
 ### Specifying the normalizing flow

--- a/nfmc/algorithms/jump/kernels.py
+++ b/nfmc/algorithms/jump/kernels.py
@@ -7,6 +7,7 @@ from nfmc.algorithms.mh.imh import IMHKernel
 from nfmc.algorithms.mh.local.hmc import HMCKernel
 from nfmc.algorithms.mh.local.mala import MALAKernel
 from nfmc.algorithms.mh.local.rwmh import RWMHKernel
+from nfmc.algorithms.nuts import NUTSKernel
 from nfmc.algorithms.preconditioning.preconditioners import DenseLinearPreconditioner, DiagonalLinearPreconditioner, NormalizingFlowPreconditioner
 from torchflows import Flow
 
@@ -45,6 +46,8 @@ def _create_local_kernel(name: str,
         return MALAKernel(event_shape, neg_log_prob_target, preconditioner=preconditioner, **kwargs)
     elif name == 'hmc':
         return HMCKernel(event_shape, neg_log_prob_target, preconditioner=preconditioner, **kwargs)
+    elif name == 'nuts':
+        return NUTSKernel(event_shape, neg_log_prob_target, preconditioner=preconditioner, **kwargs)
     else:
         raise ValueError(
             f"Unrecognized local kernel specifier string: {name}"
@@ -167,6 +170,38 @@ class NeuTraJumpHMCKernel(JumpMarkovKernel):
                 global_kernel=global_kernel,
                 flow=flow,
                 local_kernel='hmc',
+                local_preconditioner='nf',
+                global_kwargs=kwargs,
+                local_kwargs=kwargs
+            ),
+            **kwargs
+        )
+
+
+class NeuTraJumpNUTSKernel(JumpMarkovKernel):
+    """
+    Normalizing flow-preconditioned composition of a local NUTS kernel with a global jump kernel.
+    """
+
+    def __init__(self,
+                 flow: Flow,
+                 neg_log_prob_target: callable,
+                 global_kernel: str = 'imh',
+                 **kwargs):
+        """
+        JumpHMCKernel constructor.
+
+        :param Flow flow: normalizing flow for local and global preconditioning.
+        :param neg_log_prob_target: negative log probability density callable.
+        :param str global_kernel: type of global kernel. One of ['imh', 'i-sir'].
+        :param kwargs: keyword arguments for both the local and global kernels.
+        """
+        super().__init__(
+            *_create_kernels(
+                neg_log_prob_target=neg_log_prob_target,
+                global_kernel=global_kernel,
+                flow=flow,
+                local_kernel='nuts',
                 local_preconditioner='nf',
                 global_kwargs=kwargs,
                 local_kwargs=kwargs

--- a/nfmc/algorithms/mh/local/base.py
+++ b/nfmc/algorithms/mh/local/base.py
@@ -95,6 +95,6 @@ class LocalMHKernel(MHKernel):
         """
         accepted_mask = m.float()
         self._dual_averaging.step(
-            self.target_acceptance_rate - accepted_mask
+            self._target_acceptance_rate - accepted_mask
         )
         self.step_size = torch.mean(self._dual_averaging.value)

--- a/nfmc/algorithms/mh/local/base.py
+++ b/nfmc/algorithms/mh/local/base.py
@@ -64,7 +64,7 @@ class LocalMHKernel(MHKernel):
         eps_min = torch.min(torch.as_tensor(self._dual_averaging.error_sum))
         data = [
             self.name,
-            f'log step: {math.log(self.step_size):.3f}',
+            f'log step: {torch.log(self.step_size):.3f}',
             f'DA[e: {eps_mean:.2f} ^{eps_max:.2f} v{eps_min:.2f}]',
             f'{self.calls_per_second(elapsed_time_seconds):.3f} c/s',
             f'{self.grads_per_second(elapsed_time_seconds):.3f} g/s',

--- a/nfmc/algorithms/mh/local/base.py
+++ b/nfmc/algorithms/mh/local/base.py
@@ -65,10 +65,11 @@ class LocalMHKernel(MHKernel):
         data = [
             self.name,
             f'log step: {torch.log(self.step_size):.3f}',
-            f'DA[e: {eps_mean:.2f} ^{eps_max:.2f} v{eps_min:.2f}]',
+            f'DA[{eps_mean:.2f} ^{eps_max:.2f} v{eps_min:.2f}]',
             f'{self.calls_per_second(elapsed_time_seconds):.3f} c/s',
             f'{self.grads_per_second(elapsed_time_seconds):.3f} g/s',
             f'{self.acceptance_rate:.3f} acc',
+            f'{self._n_divergences} divs',
         ]
         return ', '.join(data)
 

--- a/nfmc/algorithms/mh/local/base.py
+++ b/nfmc/algorithms/mh/local/base.py
@@ -91,11 +91,10 @@ class LocalMHKernel(MHKernel):
         """
         Update kernel parameters.
 
-        :param torch.Tensor x: state tensor after kernel transition.
         :param torch.Tensor m: acceptance mask tensor after kernel transition with dtype `torch.bool`.
-        :param bool tune_step_size: if True, update the step size whenever `update=True` in the `.step` method.
-        :param bool tune_inv_mass_diag: if True, update the mass matrix whenever `update=True` in the `.step` method.
         """
         accepted_mask = m.float()
-        self._dual_averaging.step(accepted_mask)
+        self._dual_averaging.step(
+            self.target_acceptance_rate - accepted_mask
+        )
         self.step_size = torch.mean(self._dual_averaging.value)

--- a/nfmc/algorithms/mh/local/dual_averaging.py
+++ b/nfmc/algorithms/mh/local/dual_averaging.py
@@ -13,7 +13,6 @@ class DualAveraging:
 
     def __init__(self,
                  initial_step_size: float,
-                 target_acceptance_rate: float,
                  kappa: float = 0.75,
                  gamma: float = 0.05,
                  t0: int = 10,
@@ -30,8 +29,6 @@ class DualAveraging:
         :param bool store_step_sizes: if True, store step size after each step in a list.
         :param bool store_errors: if True, store acceptance rate errors after each step in a list.
         """
-        self.target_acceptance_rate = target_acceptance_rate
-
         initial_step_size = initial_step_size
 
         self.t = t0
@@ -67,26 +64,23 @@ class DualAveraging:
             return self._error_history
         return torch.stack(self._error_history)
 
-    def step(self, acceptance_mask: torch.Tensor):
+    def step(self, statistic: torch.Tensor):
         """
-        Update step size based on an incoming acceptance mask.
+        Update step size based on an incoming statistic.
 
-        :param torch.Tensor acceptance_mask: boolean tensor with shape `(n_chains,)` where the i-th element is true if
-         the kernel transition corresponding to chain i was accepted.
+        :param torch.Tensor statistic: float tensor with shape `(n_chains,)`.
         """
-        if not isinstance(acceptance_mask, torch.Tensor):
+        if not isinstance(statistic, torch.Tensor):
             raise ValueError(
-                f"Acceptance mask must be a tensor but got {type(acceptance_mask)}"
+                f"Acceptance mask must be a tensor but got {type(statistic)}"
             )
-        if len(acceptance_mask.shape) != 1:
+        if len(statistic.shape) != 1:
             raise ValueError(
-                f"Incorrect acceptance mask shape: {acceptance_mask.shape}"
+                f"Incorrect acceptance mask shape: {statistic.shape}"
             )
-
-        acceptance_rate_error = self.target_acceptance_rate - acceptance_mask.float()
 
         # This will eventually converge to 0 if all is well
-        self.error_sum += acceptance_rate_error
+        self.error_sum += statistic
 
         # Update raw step
         self.log_step = (
@@ -104,7 +98,7 @@ class DualAveraging:
         if self._store_step_sizes:
             self._step_size_history.append(self.value)
         if self._store_errors:
-            self._error_history.append(acceptance_rate_error)
+            self._error_history.append(statistic)
 
     @property
     def value(self):

--- a/nfmc/algorithms/mh/local/hmc.py
+++ b/nfmc/algorithms/mh/local/hmc.py
@@ -10,7 +10,8 @@ def hmc_step_b(x: torch.Tensor,
                momentum: torch.Tensor,
                step_size: torch.Tensor,
                neg_log_prob_target: callable,
-               event_shape: Union[Tuple[int, ...], torch.Size]):
+               event_shape: Union[Tuple[int, ...], torch.Size],
+               return_neg_log_prob_and_grad: bool = False):
     """
     HMC momentum update.
 
@@ -21,10 +22,16 @@ def hmc_step_b(x: torch.Tensor,
     :return: transformed momentum, number of target density calls, number of target density gradient calls.
     """
     if len(step_size.shape) == 1:
-        step_size = step_size.view(step_size.shape[0], *[1] * (len(x.shape) - 1))
+        step_size = step_size.view(
+            step_size.shape[0], *[1] * (len(x.shape) - 1))
 
-    _, g, nc, ng = grad_f(x, neg_log_prob_target, event_shape)
-    return momentum - step_size / 2 * g, nc, ng
+    fval, g, nc, ng = grad_f(x, neg_log_prob_target, event_shape)
+    new_momentum = momentum - step_size / 2 * g
+    
+    if return_neg_log_prob_and_grad:
+        return new_momentum, nc, ng, fval, g
+    else:
+        return new_momentum, nc, ng
 
 
 def hmc_step_a(x: torch.Tensor,
@@ -40,8 +47,53 @@ def hmc_step_a(x: torch.Tensor,
     :return: transformed position.
     """
     if len(step_size.shape) == 1:
-        step_size = step_size.view(step_size.shape[0], *[1] * (len(x.shape) - 1))
+        step_size = step_size.view(
+            step_size.shape[0], *[1] * (len(x.shape) - 1))
     return x + step_size * momentum
+
+
+def leapfrog_step(x: torch.Tensor,
+                  momentum: torch.Tensor,
+                  event_shape: Union[Tuple[int, ...], torch.Size],
+                  step_size: torch.Tensor,
+                  neg_log_prob_target: callable,
+                  return_neg_log_prob_and_grad: bool = False):
+    """
+    Perform one leapfrog step.
+
+    :param bool return_neg_log_prob_and_grad: if True, return the negative log probability
+     and its gradient from the second B step.
+    """
+    n_calls = 0
+    n_grads = 0
+
+    momentum, nc, ng = hmc_step_b(
+        x,
+        momentum,
+        step_size,
+        neg_log_prob_target,
+        event_shape
+    )
+    n_calls += nc
+    n_grads += ng
+
+    x = hmc_step_a(x, momentum, step_size)
+
+    momentum, nc, ng, fval, g = hmc_step_b(
+        x,
+        momentum,
+        step_size,
+        neg_log_prob_target,
+        event_shape,
+        return_neg_log_prob_and_grad=True
+    )
+    n_calls += nc
+    n_grads += ng
+
+    if return_neg_log_prob_and_grad:
+        return x, momentum, n_calls, n_grads, fval, g
+    else:
+        return x, momentum, n_calls, n_grads
 
 
 def hmc_trajectory(x: torch.Tensor,
@@ -70,27 +122,15 @@ def hmc_trajectory(x: torch.Tensor,
     n_grads = 0
 
     for _ in range(n_leapfrog_steps):
-        momentum, nc, ng = hmc_step_b(
-            x,
-            momentum,
-            step_size,
-            neg_log_prob_target,
-            event_shape
+        x, momentum, n_new_calls, n_new_grads = leapfrog_step(
+            x=x,
+            momentum=momentum,
+            event_shape=event_shape,
+            step_size=step_size,
+            neg_log_prob_target=neg_log_prob_target
         )
-        n_calls += nc
-        n_grads += ng
-
-        x = hmc_step_a(x, momentum, step_size)
-
-        momentum, nc, ng = hmc_step_b(
-            x,
-            momentum,
-            step_size,
-            neg_log_prob_target,
-            event_shape
-        )
-        n_calls += nc
-        n_grads += ng
+        n_calls += n_new_calls
+        n_grads += n_new_grads
 
         if full_output:
             full_trajectory.append(x)
@@ -113,7 +153,9 @@ class HMCKernel(LocalMHKernel):
         HMCKernel constructor.
 
         :param Union[Tuple[int, ...], torch.Size] event_shape: shape of the event tensor.
-        :param callable neg_log_prob_target: negative log probability density function. Takes as input a tensor with 
+        :param callable neg_log_prob_target: negative log probability density function. 
+         Takes as input an event tensor with shape `(n_chains, *event_shape)` and outputs 
+         a negative log probability tensor with shape `(n_chains,)`.
         :param int n_leapfrog_steps: number of leapfrog steps in each trajectory.
         :param kwargs: keyword arguments for the LocalMHKernel constructor.
         """

--- a/nfmc/algorithms/mh/local/hmc.py
+++ b/nfmc/algorithms/mh/local/hmc.py
@@ -236,7 +236,7 @@ class HMCKernel(LocalMHKernel):
             log_prob_accept = -hamiltonian_end - (-hamiltonian_start)
             log_u = torch.rand_like(log_prob_accept).log()
             acceptance_mask[~divergence_mask] = (log_u < log_prob_accept)
-        x[acceptance_mask] = x_prime[acceptance_mask].clone()
+        x[acceptance_mask] = x_prime[acceptance_mask]
         x = x.detach().clone()
 
         if update:

--- a/nfmc/algorithms/mh/local/hmc.py
+++ b/nfmc/algorithms/mh/local/hmc.py
@@ -27,7 +27,7 @@ def hmc_step_b(x: torch.Tensor,
 
     fval, g, nc, ng = grad_f(x, neg_log_prob_target, event_shape)
     new_momentum = momentum - step_size / 2 * g
-    
+
     if return_neg_log_prob_and_grad:
         return new_momentum, nc, ng, fval, g
     else:
@@ -148,6 +148,7 @@ class HMCKernel(LocalMHKernel):
                  event_shape: Union[Tuple[int, ...], torch.Size],
                  neg_log_prob_target: callable,
                  n_leapfrog_steps: int = 20,
+                 target_acceptance_rate: float = 0.651,
                  **kwargs):
         """
         HMCKernel constructor.
@@ -159,15 +160,12 @@ class HMCKernel(LocalMHKernel):
         :param int n_leapfrog_steps: number of leapfrog steps in each trajectory.
         :param kwargs: keyword arguments for the LocalMHKernel constructor.
         """
-        if 'dual_averaging_kwargs' not in kwargs:
-            kwargs['dual_averaging_kwargs'] = dict(
-                target_acceptance_rate=0.651
-            )
-        else:
-            if 'target_acceptance_rate' not in kwargs['dual_averaging_kwargs']:
-                kwargs['dual_averaging_kwargs']['target_acceptance_rate'] = 0.651
-
-        super().__init__(event_shape, neg_log_prob_target, **kwargs)
+        super().__init__(
+            event_shape,
+            neg_log_prob_target,
+            target_acceptance_rate=target_acceptance_rate,
+            **kwargs
+        )
         self.n_leapfrog_steps = n_leapfrog_steps
 
     @property

--- a/nfmc/algorithms/mh/local/hmc.py
+++ b/nfmc/algorithms/mh/local/hmc.py
@@ -27,6 +27,8 @@ def hmc_step_b(x: torch.Tensor,
 
     fval, g, nc, ng = grad_f(x, neg_log_prob_target, event_shape)
     new_momentum = momentum - step_size / 2 * g
+    new_momentum = new_momentum.to(x)
+    g = g.to(x)
 
     if return_neg_log_prob_and_grad:
         return new_momentum, nc, ng, fval, g
@@ -49,7 +51,9 @@ def hmc_step_a(x: torch.Tensor,
     if len(step_size.shape) == 1:
         step_size = step_size.view(
             step_size.shape[0], *[1] * (len(x.shape) - 1))
-    return x + step_size * momentum
+    new_position = x + step_size * momentum
+    new_position = new_position.to(x)
+    return new_position
 
 
 def leapfrog_step(x: torch.Tensor,

--- a/nfmc/algorithms/mh/local/mala.py
+++ b/nfmc/algorithms/mh/local/mala.py
@@ -11,12 +11,13 @@ def propose_state(x: torch.Tensor,
                   step_size: torch.Tensor,
                   neg_log_prob_target: callable):
     """
-    
+
     :param torch.Tensor x: event tensor with shape `(n_chains, *event_shape)`.
     :param torch.Tensor step_size: step size tensor with shape `(n_chains,)` or `()`.
     """
     if len(step_size.shape) == 1:
-        step_size = step_size.view(step_size.shape[0], *[1] * (len(x.shape) - 1))
+        step_size = step_size.view(
+            step_size.shape[0], *[1] * (len(x.shape) - 1))
 
     x = x.detach()
     noise = torch.randn_like(x).to(x)
@@ -37,14 +38,14 @@ def proposal_neg_log_prob(x_prime: torch.Tensor,
                           tau: torch.Tensor):
     """
     Compute the negative log probability density of the MALA proposal q(x_prime | x).
-    
+
     :param torch.Tensor x: event tensor with shape `(n_chains, *event_shape)`.
     :param torch.Tensor x_prime: proposed event tensor with shape `(n_chains, *event_shape)`.
     :param torch.Tensor tau: step size tensor with shape `(n_chains,)` or `()`.
     """
     if len(tau.shape) == 1:
         tau = tau.view(tau.shape[0], *[1] * (len(x.shape) - 1))
-    
+
     term = x_prime - (x - tau * grad_u_x)
     return sum_except_batch(term ** 2 / (4 * tau), event_shape)
 
@@ -57,6 +58,7 @@ class MALAKernel(LocalMHKernel):
     def __init__(self,
                  event_shape: Union[Tuple[int, ...], torch.Size],
                  neg_log_prob_target: callable,
+                 target_acceptance_rate: float = 0.571,
                  **kwargs):
         """
         HMCKernel constructor.
@@ -65,14 +67,12 @@ class MALAKernel(LocalMHKernel):
         :param callable neg_log_prob_target: negative log probability density function. Takes as input a tensor with 
         :param kwargs: keyword arguments for the LocalMHKernel constructor.
         """
-        if 'dual_averaging_kwargs' not in kwargs:
-            kwargs['dual_averaging_kwargs'] = dict(
-                target_acceptance_rate=0.571
-            )
-        else:
-            if 'target_acceptance_rate' not in kwargs['dual_averaging_kwargs']:
-                kwargs['dual_averaging_kwargs']['target_acceptance_rate'] = 0.571
-        super().__init__(event_shape, neg_log_prob_target, **kwargs)
+        super().__init__(
+            event_shape,
+            neg_log_prob_target,
+            target_acceptance_rate=target_acceptance_rate,
+            **kwargs
+        )
 
     @property
     def name(self):

--- a/nfmc/algorithms/mh/local/rwmh.py
+++ b/nfmc/algorithms/mh/local/rwmh.py
@@ -7,13 +7,14 @@ from nfmc.util import compute_divergence_mask, metropolis_acceptance_log_ratio
 
 def propose_state(x: torch.Tensor, step_size: torch.Tensor):
     """
-    
+
     :param torch.Tensor x: event tensor with shape `(n_chains, *event_shape)`.
     :param torch.Tensor step_size: step size tensor with shape `(n_chains,)` or `()`.
     """
     if len(step_size.shape) == 1:
-        step_size = step_size.view(step_size.shape[0], *[1] * (len(x.shape) - 1))
-    
+        step_size = step_size.view(
+            step_size.shape[0], *[1] * (len(x.shape) - 1))
+
     x_prime = x + step_size * torch.randn_like(x)
     return x_prime
 
@@ -26,6 +27,7 @@ class RWMHKernel(LocalMHKernel):
     def __init__(self,
                  event_shape: Union[Tuple[int, ...], torch.Size],
                  neg_log_prob_target: callable,
+                 target_acceptance_rate: float = 0.234,
                  **kwargs):
         """
         RWMH kernel class constructor.
@@ -36,18 +38,15 @@ class RWMHKernel(LocalMHKernel):
          `batch_shape`.
         :param float step_size: proposal step size.
         """
-        if 'dual_averaging_kwargs' not in kwargs:
-            kwargs['dual_averaging_kwargs'] = dict(
-                target_acceptance_rate=0.234
-            )
-        else:
-            if 'target_acceptance_rate' not in kwargs['dual_averaging_kwargs']:
-                kwargs['dual_averaging_kwargs']['target_acceptance_rate'] = 0.234
-
         if 'step_size' not in kwargs:
             event_size = int(torch.prod(torch.as_tensor(event_shape)))
             kwargs['step_size'] = torch.tensor(2.38 ** 2 / event_size)
-        super().__init__(event_shape, neg_log_prob_target, **kwargs)
+        super().__init__(
+            event_shape,
+            neg_log_prob_target,
+            target_acceptance_rate=target_acceptance_rate,
+            **kwargs
+        )
 
     @property
     def name(self):

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -1,9 +1,8 @@
-import math
 from typing import Tuple, Union
 from dataclasses import dataclass
 
 import torch
-from nfmc.algorithms.kernel import MarkovKernel
+from nfmc.algorithms.mh.local.base import LocalMHKernel
 from nfmc.util import sum_except_batch
 from nfmc.algorithms.mh.local.hmc import leapfrog_step
 
@@ -52,7 +51,7 @@ class ParallelTreeState:
         self.sum_accept_prob = torch.zeros(size=(self.n_chains,))
         self.stop = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
         self.diverged = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
-        self.n_leapfrogs = torch.zeros(size=(self.n_chains,))
+        self.n_leapfrogs = torch.zeros(size=(self.n_chains,), dtype=torch.long)
 
     def masked_copy(self, mask: torch.Tensor):
         """
@@ -131,7 +130,7 @@ def _build_tree(x: torch.Tensor,
                 step_size: torch.Tensor,
                 neg_log_prob_target: callable,
                 log_prob_x: torch.Tensor,
-                max_delta: float) -> ParallelTreeState:
+                max_delta: float) -> Tuple[ParallelTreeState, int, int]:
     """
     Build a balanced binary tree.
     A separate tree is built individually for each chain state via vectorization.
@@ -162,7 +161,7 @@ def _build_tree(x: torch.Tensor,
     # Base case
     if m_b.any():
         # Perform a single leapfrog step
-        x1, p1, _, _, neg_log_prob1, g1 = leapfrog_step(
+        x1, p1, nc, ng, neg_log_prob1, g1 = leapfrog_step(
             x=x[m_b],
             momentum=p[m_b],
             event_shape=event_shape,
@@ -196,12 +195,12 @@ def _build_tree(x: torch.Tensor,
         state.stop[m_b] = diverged
         state.diverged[m_b] = diverged
 
-        return state
+        return state, nc, ng
 
     # General case
     if m_g.any():
         # Build the left subtree (`n_g` chains)
-        left = _build_tree(
+        left, nc_left, ng_left = _build_tree(
             x=x[m_g],
             p=p[m_g],
             event_shape=event_shape,
@@ -248,7 +247,7 @@ def _build_tree(x: torch.Tensor,
             left_continue.p_plus[m_g_non_early_positive]
         )
 
-        right = _build_tree(
+        right, nc_right, ng_right = _build_tree(
             x=x_start[m_g_non_early],
             p=p_start[m_g_non_early],
             event_shape=event_shape,
@@ -349,10 +348,10 @@ def _build_tree(x: torch.Tensor,
             right.p_plus
         )
 
-        return state
+        return state, nc_left + nc_right, ng_left + ng_right
 
 
-class NUTSKernel(MarkovKernel):
+class NUTSKernel(LocalMHKernel):
     """
     Implementation of the no-U-turn sampler (NUTS) transition kernel.
     """
@@ -392,99 +391,129 @@ class NUTSKernel(MarkovKernel):
         :param bool update: if True, update kernel parameters.
         :return: new state tensor with shape `(*batch_shape, *event_shape)`.
         """
+        n_chains = x.shape[0]
+
         if self.warmup_active:
             step_size = self._dual_averaging.value
         else:
             step_size = self.step_size
+            if step_size.shape != (n_chains,):
+                if step_size.shape != ():
+                    raise ValueError(
+                        f"Step size should have `{n_chains = }` elements or a single one, but got {step_size.shape = }")
+                step_size = torch.full(
+                    size=(n_chains,), fill_value=step_size.item())
 
-        log_prob = -self.neg_log_prob_target(x)
+        log_prob_x = -self.neg_log_prob_target(x)
 
         # Sample momentum and slice variable
         p0 = torch.randn_like(x)
-        joint0 = float(log_prob - _kinetic_energy(p0, self.event_shape))
-        u_slice = torch.rand(()) * math.exp(joint0)
+        joint0 = log_prob_x - _kinetic_energy(p0, self.event_shape)
+        u_slice = torch.rand_like(step_size) * torch.exp(joint0)
 
         # Initialize balanced binary tree
         x_minus, x_plus = x.clone(), x.clone()
         p_minus, p_plus = p0.clone(), p0.clone()
         x_prime = x.clone()
-        log_prob_prime = log_prob.clone()
+        log_prob_x_prime = log_prob_x.clone()
+
+        # Initialize other variables
+        n_valid = torch.zeros(size=(n_chains,), dtype=torch.long)
+        sum_accept = torch.zeros(size=(n_chains,))
+        n_lf_total = torch.zeros(size=(n_chains,), dtype=torch.long)
+        stop = torch.zeros(size=(n_chains,), dtype=torch.bool)
+        diverged = torch.zeros(size=(n_chains,), dtype=torch.bool)
 
         for j in range(self.max_tree_depth + 1):
             # Choose direction
-            if torch.randint(0, 2, ()).item() == 1:
-                v = 1
-            else:
-                v = -1
+            v = torch.randint_like(step_size, low=0, high=2) * 2 - 1
 
-            if v == -1:
-                # Build tree into negative time direction
-                state: ParallelTreeState = _build_tree()
-                x_minus, p_minus = state.x_minus, state.p_minus
-            else:
-                # Build tree into positive time direction
-                state: ParallelTreeState = _build_tree()
-                x_plus, p_plus = state.x_plus, state.p_plus
+            # Build tree into negative/positive time directions
+            # (determined according to v within _build_tree)
+            m_neg = (v == -1)
 
-            # Select state among valid states
+            _x_build_tree = x_plus.clone()
+            _x_build_tree[m_neg] = x_minus[m_neg]
+            _p_build_tree = p_plus.clone()
+            _p_build_tree[m_neg] = p_minus[m_neg]
 
-            pass
+            state, nc, ng = _build_tree(
+                x=_x_build_tree,
+                p=_p_build_tree,
+                event_shape=self.event_shape,
+                u_slice=u_slice,
+                v=v,
+                j=torch.full(size=(n_chains,), fill_value=j),
+                step_size=step_size,
+                neg_log_prob_target=self.neg_log_prob_target,
+                log_prob_x=log_prob_x,
+                max_delta=self.max_delta
+            )
+            state: ParallelTreeState
+
+            (
+                x_minus[m_neg],
+                p_minus[m_neg]
+            ) = (
+                state.x_minus[m_neg],
+                state.p_minus[m_neg]
+            )
+
+            (
+                x_plus[~m_neg],
+                p_plus[~m_neg]
+            ) = (
+                state.x_plus[~m_neg],
+                state.p_plus[~m_neg]
+            )
+            stop[state.stop] = True
+            diverged[state.diverged] = True
+
+            # Update state (select state among valid states)
+            m_update = (
+                state.n_valid > 0
+                & (torch.rand(size=(n_chains,)) < (state.n_valid / (n_valid + state.n_valid)))
+            )
+            x_prime[m_update] = state.x_prime[m_update].clone()
+            log_prob_x_prime[m_update] = state.log_prob_prime[m_update].clone()
+
+            n_valid += state.n_valid
+            sum_accept += state.sum_accept_prob
+            n_lf_total += state.n_leapfrogs
+
+            if stop.all():
+                break
+            if is_uturn(
+                x_minus=x_minus,
+                x_plus=x_plus,
+                p_minus=p_minus,
+                p_plus=p_plus,
+            ).all():
+                break
 
         # Accept proposal
+        x = x_prime
+        log_prob_x = log_prob_x_prime
 
-        # Sample momentum and simulate trajectory
-        x_prime, p_prime, nc, ng = hmc_trajectory(
-            x=x.clone(),
-            momentum=p,
-            event_shape=self.event_shape,
-            step_size=step_size,
-            n_leapfrog_steps=self.n_leapfrog_steps,
-            neg_log_prob_target=self.neg_log_prob_target
-        )
+        # Dual averaging statistic
+        if update:
+            h_da = sum_accept / torch.clip(n_lf_total, max=torch.tensor(1.0))
+            self._update(h_da)
+
         self.increment_n_calls(nc)
         self.increment_n_grads(ng)
-
-        # Compute divergence mask
-        divergence_mask_x = compute_divergence_mask(x_prime, self.event_shape)
-        divergence_mask_p = compute_divergence_mask(p_prime, self.event_shape)
-        divergence_mask = divergence_mask_x | divergence_mask_p
-
-        n_valid_proposals = int((~divergence_mask).long().sum())
-        self.increment_n_divergences(int(divergence_mask.long().sum()))
-
-        # Compute acceptance mask
-        acceptance_mask = torch.zeros_like(divergence_mask)
-        if n_valid_proposals > 0:
-            hamiltonian_start: torch.Tensor = (
-                self.neg_log_prob_target(x[~divergence_mask])
-                + 0.5 * sum_except_batch(
-                    p[~divergence_mask] ** 2,
-                    self.event_shape
-                )
-            )
-            self.increment_n_calls(n_valid_proposals)
-
-            hamiltonian_end: torch.Tensor = (
-                self.neg_log_prob_target(x_prime[~divergence_mask])
-                + 0.5 * sum_except_batch(
-                    p_prime[~divergence_mask] ** 2,
-                    self.event_shape
-                )
-            )
-            self.increment_n_calls(n_valid_proposals)
-
-            log_prob_accept = -hamiltonian_end - (-hamiltonian_start)
-            log_u = torch.rand_like(log_prob_accept).log()
-            acceptance_mask[~divergence_mask] = (log_u < log_prob_accept)
-        x[acceptance_mask] = x_prime[acceptance_mask].clone()
-        x = x.detach().clone()
-
-        if update:
-            self._update(acceptance_mask)
-
+        self.increment_n_divergences(int(state.diverged.long().sum()))
         self.increment_n_steps()
-        self.increment_n_attempted_transitions(n_chains=x.shape[0])
-        self.increment_n_accepted_transitions(
-            int(acceptance_mask.long().sum()))
+        self.increment_n_attempted_transitions(n_chains=n_chains)
+        self.increment_n_accepted_transitions(n_chains)
 
         return x
+
+    def _update(self, h: torch.Tensor):
+        """
+        Update kernel parameters.
+
+        :param torch.Tensor h: statistic tensor after kernel transition.
+        """
+        self._dual_averaging.step(h)
+        self.step_size = torch.mean(self._dual_averaging.value)

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -38,32 +38,40 @@ class ParallelTreeState:
     n_leapfrogs: torch.Tensor = None
 
     def __post_init__(self):
-        self.x_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
-        self.x_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
+        if self.x_minus is None:
+            self.x_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
 
-        self.p_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
-        self.p_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
+        if self.x_plus is None:
+            self.x_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
 
-        self.x_prime = torch.zeros(size=(self.n_chains, *self.event_shape))
-        self.log_prob_prime = torch.zeros(size=(self.n_chains,))
+        if self.p_minus is None:
+            self.p_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
 
-        self.n_valid = torch.zeros(size=(self.n_chains,), dtype=torch.long)
-        self.sum_accept_prob = torch.zeros(size=(self.n_chains,))
-        self.stop = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
-        self.diverged = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
-        self.n_leapfrogs = torch.zeros(size=(self.n_chains,), dtype=torch.long)
-    
-    def to(self, tensor: torch.Tensor):
-        self.x_minus = self.x_minus.to(tensor)
-        self.x_plus = self.x_plus.to(tensor)
-        
-        self.p_minus = self.p_minus.to(tensor)
-        self.p_plus = self.p_plus.to(tensor)
+        if self.p_plus is None:
+            self.p_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
 
-        self.x_prime = self.x_prime.to(tensor)
-        self.log_prob_prime = self.log_prob_prime.to(tensor)
+        if self.x_prime is None:
+            self.x_prime = torch.zeros(size=(self.n_chains, *self.event_shape))
 
-        return self
+        if self.log_prob_prime is None:
+            self.log_prob_prime = torch.zeros(size=(self.n_chains,))
+
+        if self.n_valid is None:
+            self.n_valid = torch.zeros(size=(self.n_chains,), dtype=torch.long)
+
+        if self.sum_accept_prob is None:
+            self.sum_accept_prob = torch.zeros(size=(self.n_chains,))
+
+        if self.stop is None:
+            self.stop = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
+
+        if self.diverged is None:
+            self.diverged = torch.zeros(
+                size=(self.n_chains,), dtype=torch.bool)
+
+        if self.n_leapfrogs is None:
+            self.n_leapfrogs = torch.zeros(
+                size=(self.n_chains,), dtype=torch.long)
 
     def masked_copy(self, mask: torch.Tensor):
         """
@@ -72,20 +80,20 @@ class ParallelTreeState:
         return ParallelTreeState(
             n_chains=int(mask.sum()),
             event_shape=self.event_shape,
-            x_minus=self.x_minus[mask].clone().to(self.x_minus),
-            x_plus=self.x_plus[mask].clone().to(self.x_plus),
+            x_minus=self.x_minus[mask],
+            x_plus=self.x_plus[mask],
 
-            p_minus=self.p_minus[mask].clone().to(self.p_minus),
-            p_plus=self.p_plus[mask].clone().to(self.p_plus),
+            p_minus=self.p_minus[mask],
+            p_plus=self.p_plus[mask],
 
-            x_prime=self.x_prime[mask].clone().to(self.x_prime),
-            log_prob_prime=self.log_prob_prime[mask].clone().to(self.log_prob_prime),
+            x_prime=self.x_prime[mask],
+            log_prob_prime=self.log_prob_prime[mask],
 
-            n_valid=self.n_valid[mask].clone(),
-            sum_accept_prob=self.sum_accept_prob[mask].clone(),
-            stop=self.stop[mask].clone(),
-            diverged=self.diverged[mask].clone(),
-            n_leapfrogs=self.n_leapfrogs[mask].clone(),
+            n_valid=self.n_valid[mask],
+            sum_accept_prob=self.sum_accept_prob[mask],
+            stop=self.stop[mask],
+            diverged=self.diverged[mask],
+            n_leapfrogs=self.n_leapfrogs[mask],
         )
 
     def overwrite_with(self, other_state, mask: torch.Tensor):
@@ -98,14 +106,14 @@ class ParallelTreeState:
             raise ValueError(
                 f"Shape of overwrite mask should be equal to {(self.n_chains,)}, but got {mask.shape}"
             )
-        self.x_minus[mask] = other_state.x_minus.to(self.x_minus)
-        self.x_plus[mask] = other_state.x_plus.to(self.x_plus)
+        self.x_minus[mask] = other_state.x_minus
+        self.x_plus[mask] = other_state.x_plus
 
-        self.p_minus[mask] = other_state.p_minus.to(self.p_minus)
-        self.p_plus[mask] = other_state.p_plus.to(self.p_plus)
+        self.p_minus[mask] = other_state.p_minus
+        self.p_plus[mask] = other_state.p_plus
 
-        self.x_prime[mask] = other_state.x_prime.to(self.x_prime)
-        self.log_prob_prime[mask] = other_state.log_prob_prime.to(self.log_prob_prime)
+        self.x_prime[mask] = other_state.x_prime
+        self.log_prob_prime[mask] = other_state.log_prob_prime
         self.n_valid[mask] = other_state.n_valid
         self.sum_accept_prob[mask] = other_state.sum_accept_prob
         self.stop[mask] = other_state.stop
@@ -120,7 +128,7 @@ def _acceptance_prob(log_prob_new,
                      event_shape):
     h_new = -log_prob_new + _kinetic_energy(momentum_new, event_shape)
     h_old = -log_prob_old + _kinetic_energy(momentum_old, event_shape)
-    return torch.clamp(torch.exp(h_old-h_new), max=1.0)
+    return torch.clamp(torch.exp(h_old - h_new), max=1.0)
 
 
 def is_uturn(x_minus,
@@ -161,12 +169,24 @@ def _build_tree(x: torch.Tensor,
     :param torch.Tensor log_prob_x: log probability density of incoming position tensor x with shape `(n_chains,)`.
     :param float max_delta: energy error divergence threshold.
     """
+    nc = 0
+    ng = 0
+    n_chains = x.shape[0]
 
-    # Clone position and momentum tensors
+    # Create a new state
     state = ParallelTreeState(
-        n_chains=x.shape[0],
+        n_chains=n_chains,
         event_shape=event_shape
-    ).to(x)
+    )
+    state.x_minus = state.x_minus.to(x.dtype)
+    state.x_plus = state.x_plus.to(x.dtype)
+    state.p_minus = state.p_minus.to(x.dtype)
+    state.p_plus = state.p_plus.to(x.dtype)
+    state.x_prime = state.x_prime.to(x.dtype)
+    state.log_prob_prime = state.log_prob_prime.to(x.dtype)
+
+    if v.shape != (n_chains,):
+        raise ValueError(f"Expected v.shape = ({n_chains},), but got {v.shape = }")
 
     m_b = (j == 0)  # Base case mask
     m_g = (j > 0)   # General case mask
@@ -179,7 +199,7 @@ def _build_tree(x: torch.Tensor,
     # Base case
     if m_b.any():
         # Perform a single leapfrog step
-        x1, p1, nc, ng, neg_log_prob1, g1 = leapfrog_step(
+        x1, p1, nc_b, ng_b, neg_log_prob1, g1 = leapfrog_step(
             x=x[m_b],
             momentum=p[m_b],
             event_shape=event_shape,
@@ -208,15 +228,16 @@ def _build_tree(x: torch.Tensor,
             log_prob_x[m_b],
             p[m_b],
             event_shape
-        )
+        ).to(state.sum_accept_prob.dtype)
         state.n_leapfrogs[m_b] = 1
         state.stop[m_b] = diverged
         state.diverged[m_b] = diverged
 
-        return state, nc, ng
+        nc += nc_b
+        ng += ng_b
 
     # General case
-    elif m_g.any():
+    if m_g.any():
         # Build the left subtree (`n_g` chains)
         left, nc_left, ng_left = _build_tree(
             x=x[m_g],
@@ -230,6 +251,8 @@ def _build_tree(x: torch.Tensor,
             log_prob_x=log_prob_x[m_g],
             max_delta=max_delta
         )
+        nc += nc_left
+        ng += ng_left
 
         # Split the left subtree according to early stopping:
         # - left_early (`n_g_e` chains) is the tree with early stopping. For
@@ -244,116 +267,116 @@ def _build_tree(x: torch.Tensor,
         state.overwrite_with(left_early, m_g_early)
         m_g_non_early = ~m_g_early  # Mask for non-early-stopped chains
 
-        if not m_g_non_early.any():
-            return left, nc_left, ng_left
+        if m_g_non_early.any():
+            left_continue = left.masked_copy(m_g_non_early)
 
-        left_continue = left.masked_copy(m_g_non_early)
+            # (`n_g_c` chains)
+            m_g_non_early_negative = (v[m_g_non_early] == -1)
+            m_g_non_early_positive = ~m_g_non_early_negative
 
-        # (`n_g_c` chains)
-        m_g_non_early_negative = (v[m_g_non_early] == -1)
-        m_g_non_early_positive = ~m_g_non_early_negative
+            x_start, p_start = x.clone(), p.clone()  # (`n` chains)
+            (
+                x_start[m_g_non_early][m_g_non_early_negative],
+                p_start[m_g_non_early][m_g_non_early_negative]
+            ) = (
+                left_continue.x_minus[m_g_non_early_negative],
+                left_continue.p_minus[m_g_non_early_negative]
+            )
+            (
+                x_start[m_g_non_early][m_g_non_early_positive],
+                p_start[m_g_non_early][m_g_non_early_positive]
+            ) = (
+                left_continue.x_plus[m_g_non_early_positive],
+                left_continue.p_plus[m_g_non_early_positive]
+            )
 
-        x_start, p_start = x.clone(), p.clone()  # (`n` chains)
-        (
-            x_start[m_g_non_early][m_g_non_early_negative],
-            p_start[m_g_non_early][m_g_non_early_negative]
-        ) = (
-            left_continue.x_minus[m_g_non_early_negative],
-            left_continue.p_minus[m_g_non_early_negative]
-        )
-        (
-            x_start[m_g_non_early][m_g_non_early_positive],
-            p_start[m_g_non_early][m_g_non_early_positive]
-        ) = (
-            left_continue.x_plus[m_g_non_early_positive],
-            left_continue.p_plus[m_g_non_early_positive]
-        )
+            right, nc_right, ng_right = _build_tree(
+                x=x_start[m_g_non_early],
+                p=p_start[m_g_non_early],
+                event_shape=event_shape,
+                u_slice=u_slice[m_g_non_early],
+                v=v[m_g_non_early],
+                j=j[m_g_non_early] - 1,
+                step_size=step_size[m_g_non_early],
+                neg_log_prob_target=neg_log_prob_target,
+                log_prob_x=log_prob_x[m_g_non_early],
+                max_delta=max_delta
+            )
 
-        right, nc_right, ng_right = _build_tree(
-            x=x_start[m_g_non_early],
-            p=p_start[m_g_non_early],
-            event_shape=event_shape,
-            u_slice=u_slice[m_g_non_early],
-            v=v[m_g_non_early],
-            j=j[m_g_non_early] - 1,
-            step_size=step_size[m_g_non_early],
-            neg_log_prob_target=neg_log_prob_target,
-            log_prob_x=log_prob_x[m_g_non_early],
-            max_delta=max_delta
-        )
+            # Combine
+            # > Left (non early stopped)
+            state.x_minus[m_g_non_early][m_g_non_early_negative] = left_continue.x_minus[m_g_non_early_negative]
+            state.p_minus[m_g_non_early][m_g_non_early_negative] = left_continue.p_minus[m_g_non_early_negative]
+            state.x_plus[m_g_non_early][m_g_non_early_negative] = left_continue.x_plus[m_g_non_early_negative]
+            state.p_plus[m_g_non_early][m_g_non_early_negative] = left_continue.p_plus[m_g_non_early_negative]
 
-        # Combine
-        # > Left (non early stopped)
-        state.x_minus[m_g_non_early][m_g_non_early_negative] = left_continue.x_minus[m_g_non_early_negative]
-        state.p_minus[m_g_non_early][m_g_non_early_negative] = left_continue.p_minus[m_g_non_early_negative]
-        state.x_plus[m_g_non_early][m_g_non_early_negative] = left_continue.x_plus[m_g_non_early_negative]
-        state.p_plus[m_g_non_early][m_g_non_early_negative] = left_continue.p_plus[m_g_non_early_negative]
+            # Right
+            state.x_minus[m_g_non_early][m_g_non_early_positive] = right.x_minus[m_g_non_early_positive]
+            state.p_minus[m_g_non_early][m_g_non_early_positive] = right.p_minus[m_g_non_early_positive]
+            state.x_plus[m_g_non_early][m_g_non_early_positive] = right.x_plus[m_g_non_early_positive]
+            state.p_plus[m_g_non_early][m_g_non_early_positive] = right.p_plus[m_g_non_early_positive]
 
-        # Right
-        state.x_minus[m_g_non_early][m_g_non_early_positive] = right.x_minus[m_g_non_early_positive]
-        state.p_minus[m_g_non_early][m_g_non_early_positive] = right.p_minus[m_g_non_early_positive]
-        state.x_plus[m_g_non_early][m_g_non_early_positive] = right.x_plus[m_g_non_early_positive]
-        state.p_plus[m_g_non_early][m_g_non_early_positive] = right.p_plus[m_g_non_early_positive]
+            # Choose a proposal uniformly from valid points
+            state.n_valid[m_g_non_early] = left_continue.n_valid + right.n_valid
+            valid_g_non_early = state.n_valid[m_g_non_early] > 0  # (< n_g_c)
 
-        # Choose a proposal uniformly from valid points
-        state.n_valid[m_g_non_early] = left_continue.n_valid + right.n_valid
-        valid_g_non_early = state.n_valid[m_g_non_early] > 0  # (< n_g_c)
+            # If1
+            _rand = torch.rand((int(m_g_non_early.long().sum()),), dtype=x.dtype)
+            _thresh = right.n_valid / state.n_valid[m_g_non_early]
+            rand_mask = _rand < _thresh
 
-        # If1
-        rand_mask = torch.less(
-            torch.rand(int(m_g_non_early.long().sum()),),
-            right.n_valid / state.n_valid[m_g_non_early]
-        )
+            # If2
+            (
+                state.x_prime[m_g_non_early][rand_mask],
+                state.log_prob_prime[m_g_non_early][rand_mask]
+            ) = (
+                right.x_prime[rand_mask],
+                right.log_prob_prime[rand_mask]
+            )
+            # Else2
+            (
+                state.x_prime[m_g_non_early][~rand_mask],
+                state.log_prob_prime[m_g_non_early][~rand_mask]
+            ) = (
+                left_continue.x_prime[~rand_mask],
+                left_continue.log_prob_prime[~rand_mask]
+            )
+            # Endif2
 
-        # If2
-        (
-            state.x_prime[m_g_non_early][rand_mask],
-            state.log_prob_prime[m_g_non_early][rand_mask]
-        ) = (
-            right.x_prime[rand_mask],
-            right.log_prob_prime[rand_mask]
-        )
-        # Else2
-        (
-            state.x_prime[m_g_non_early][~rand_mask],
-            state.log_prob_prime[m_g_non_early][~rand_mask]
-        ) = (
-            left_continue.x_prime[~rand_mask],
-            left_continue.log_prob_prime[~rand_mask]
-        )
-        # Endif2
+            # Else1
+            (
+                state.x_prime[m_g_non_early][~valid_g_non_early],
+                state.log_prob_prime[m_g_non_early][~valid_g_non_early]
+            ) = (
+                left_continue.x_prime[left_continue.n_valid == 0],
+                left_continue.log_prob_prime[left_continue.n_valid == 0]
+            )
+            # EndIf1
 
-        # Else1
-        (
-            state.x_prime[m_g_non_early][~valid_g_non_early],
-            state.log_prob_prime[m_g_non_early][~valid_g_non_early]
-        ) = (
-            left_continue.x_prime[left_continue.n_valid == 0],
-            left_continue.log_prob_prime[left_continue.n_valid == 0]
-        )
-        # EndIf1
+            state.sum_accept_prob[m_g_non_early] = (
+                left_continue.sum_accept_prob
+                + right.sum_accept_prob
+            )
+            state.n_leapfrogs[m_g_non_early] = (
+                left_continue.n_leapfrogs
+                + right.n_leapfrogs
+            )
+            state.diverged[m_g_non_early] = left_continue.diverged | right.diverged
 
-        state.sum_accept_prob[m_g_non_early] = (
-            left_continue.sum_accept_prob
-            + right.sum_accept_prob
-        )
-        state.n_leapfrogs[m_g_non_early] = (
-            left_continue.n_leapfrogs
-            + right.n_leapfrogs
-        )
-        state.diverged[m_g_non_early] = left_continue.diverged | right.diverged
+            state.stop[m_g_non_early] = right.stop | is_uturn(
+                left_continue.x_minus,
+                right.x_plus,
+                left_continue.p_minus,
+                right.p_plus,
+                event_shape=event_shape
+            )
 
-        state.stop[m_g_non_early] = right.stop | is_uturn(
-            left_continue.x_minus,
-            right.x_plus,
-            left_continue.p_minus,
-            right.p_plus,
-            event_shape=event_shape
-        )
+            nc += nc_right
+            ng += ng_right
 
-        return state, nc_left + nc_right, ng_left + ng_right
-    else:
-        raise ValueError("Recursion did not use base or general case in any chain")
+    return state, nc, ng
+    
+
 
 class NUTSKernel(LocalMHKernel):
     """
@@ -363,7 +386,7 @@ class NUTSKernel(LocalMHKernel):
     def __init__(self,
                  event_shape: Union[Tuple[int, ...], torch.Size],
                  neg_log_prob_target: callable,
-                 max_tree_depth: int = 10,
+                 max_tree_depth: int = 5,
                  max_delta: float = 1000.0,
                  **kwargs):
         """
@@ -397,23 +420,30 @@ class NUTSKernel(LocalMHKernel):
         """
         n_chains = x.shape[0]
 
+        # Choose step size according to warmup flag
         if self.warmup_active:
             step_size = self._dual_averaging.value
         else:
             step_size = self.step_size
-            if step_size.shape != (n_chains,):
-                if step_size.shape != ():
-                    raise ValueError(
-                        f"Step size should have `{n_chains = }` elements or a single one, but got {step_size.shape = }")
-                step_size = torch.full(
-                    size=(n_chains,), fill_value=step_size.item())
 
-        log_prob_x = -self.neg_log_prob_target(x).to(x)
+        # Ensure step size has appropriate shape
+        if step_size.shape != (n_chains,):
+            if step_size.shape != ():
+                raise ValueError(
+                    f"Step size should have `{n_chains=}` elements or a single one, but got {step_size.shape = }"
+                )
+            step_size = torch.full(
+                size=(n_chains,), 
+                fill_value=step_size.item()
+            )
+        step_size = step_size.to(x.dtype)
+
+        log_prob_x = -self.neg_log_prob_target(x).to(x.dtype)
 
         # Sample momentum and slice variable
         p0 = torch.randn_like(x)
         joint0 = log_prob_x - _kinetic_energy(p0, self.event_shape)
-        u_slice = torch.rand_like(step_size).to(x) * torch.exp(joint0).to(x)
+        u_slice = torch.rand_like(step_size) * torch.exp(joint0)
 
         # Initialize balanced binary tree
         x_minus, x_plus = x.clone(), x.clone()
@@ -430,7 +460,8 @@ class NUTSKernel(LocalMHKernel):
 
         for j in range(self.max_tree_depth + 1):
             # Choose direction
-            v = torch.randint_like(step_size, low=0, high=2) * 2 - 1
+            _r = torch.randint(size=(n_chains,), low=0, high=2).to(step_size.dtype)
+            v = _r * 2 - 1
 
             # Build tree into negative/positive time directions
             # (determined according to v within _build_tree)
@@ -474,11 +505,11 @@ class NUTSKernel(LocalMHKernel):
             diverged[state.diverged] = True
 
             # Update state (select state among valid states)
-            _rand = torch.rand(size=(n_chains,)).to(x)
+            _rand = torch.rand_like(step_size)
             _thresh = state.n_valid / (n_valid + state.n_valid)
             m_update = (state.n_valid > 0) & (_rand < _thresh)
-            x_prime[m_update] = state.x_prime[m_update].clone()
-            log_prob_x_prime[m_update] = state.log_prob_prime[m_update].clone()
+            x_prime[m_update] = state.x_prime[m_update]
+            log_prob_x_prime[m_update] = state.log_prob_prime[m_update]
 
             n_valid += state.n_valid
             sum_accept += state.sum_accept_prob

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -1,0 +1,413 @@
+import math
+from typing import Tuple, Union
+from dataclasses import dataclass
+
+import torch
+from nfmc.algorithms.kernel import MarkovKernel
+from nfmc.util import sum_except_batch
+from nfmc.algorithms.mh.local.hmc import leapfrog_step
+
+
+@torch.no_grad()
+def _kinetic_energy(p: torch.Tensor, event_shape: Union[Tuple[int, ...], torch.Size]) -> torch.Tensor:
+    # Identity mass => 0.5 * p^T p
+    return 0.5 * sum_except_batch((p * p), event_shape)
+
+
+@dataclass
+class ParallelTreeState:
+    n_chains: int
+    event_shape: Union[Tuple[int, ...], torch.Size]
+
+    # Position variables
+    x_minus: torch.Tensor = None
+    x_plus: torch.Tensor = None
+
+    # Momentum variables
+    p_minus: torch.Tensor = None
+    p_plus: torch.Tensor = None
+
+    # Proposed state variables
+    x_prime: torch.Tensor = None
+    log_prob_prime: torch.Tensor = None
+
+    # Other variables
+    n_valid: torch.Tensor = None
+    sum_accept_prob: torch.Tensor = None
+    stop: torch.Tensor = None
+    diverged: torch.Tensor = None
+    n_leapfrogs: torch.Tensor = None
+
+    def __post_init__(self):
+        self.x_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
+        self.x_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
+
+        self.p_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
+        self.p_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
+
+        self.x_prime = torch.zeros(size=(self.n_chains, *self.event_shape))
+        self.log_prob_prime = torch.zeros(size=(self.n_chains,))
+
+        self.n_valid = torch.zeros(size=(self.n_chains,), dtype=torch.long)
+        self.sum_accept_prob = torch.zeros(size=(self.n_chains,))
+        self.stop = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
+        self.diverged = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
+        self.n_leapfrogs = torch.zeros(size=(self.n_chains,))
+
+    def masked_copy(self, mask: torch.Tensor):
+        """
+        Create a copy of this state, retaining only masked chains.
+        """
+        return ParallelTreeState(
+            n_chains=int(mask.sum()),
+            event_shape=self.event_shape,
+            x_minus=self.x_minus[mask].clone(),
+            x_plus=self.x_plus[mask].clone(),
+
+            p_minus=self.p_minus[mask].clone(),
+            p_plus=self.p_plus[mask].clone(),
+
+            x_prime=self.x_prime[mask].clone(),
+            log_prob_prime=self.log_prob_prime[mask].clone(),
+
+            n_valid=self.n_valid[mask].clone(),
+            sum_accept_prob=self.sum_accept_prob[mask].clone(),
+            stop=self.stop[mask].clone(),
+            diverged=self.diverged[mask].clone(),
+            n_leapfrogs=self.n_leapfrogs[mask].clone(),
+        )
+
+    def overwrite_with(self, other_state, mask: torch.Tensor):
+        """
+        Overwrite this state's data with other state's data.
+        The other state may have fewer chains. 
+        The affected chains for this state are determined by the mask.
+        """
+        if not mask.shape == (self.n_chains,):
+            raise ValueError(
+                f"Shape of overwrite mask should be equal to {(self.n_chains,)}, but got {mask.shape}"
+            )
+        self.x_minus[mask] = other_state.x_minus
+        self.x_plus[mask] = other_state.x_plus
+
+        self.p_minus[mask] = other_state.p_minus
+        self.p_plus[mask] = other_state.p_plus
+
+        self.x_prime[mask] = other_state.x_prime
+        self.log_prob_prime[mask] = other_state.log_prob_prime
+        self.n_valid[mask] = other_state.n_valid
+        self.sum_accept_prob[mask] = other_state.sum_accept_prob
+        self.stop[mask] = other_state.stop
+        self.diverged[mask] = other_state.diverged
+        self.n_leapfrogs[mask] = other_state.n_leapfrogs
+
+
+def _acceptance_prob(log_prob_new,
+                     momentum_new,
+                     log_prob_old,
+                     momentum_old):
+    h_new = -log_prob_new + _kinetic_energy(momentum_new)
+    h_old = -log_prob_old + _kinetic_energy(momentum_old)
+    return torch.clamp(torch.exp(h_old-h_new), max=1.0)
+
+
+def is_uturn(x_minus,
+             x_plus,
+             p_minus,
+             p_plus):
+    dx = x_plus - x_minus
+    m1 = torch.einsum('...i,...j->...', dx, p_minus) < 0
+    m2 = torch.einsum('...i,...j->...', dx, p_plus) < 0
+    return m1 | m2
+
+
+def _build_tree(x: torch.Tensor,
+                p: torch.Tensor,
+                event_shape: Union[torch.Size, Tuple[int, ...]],
+                u_slice: torch.Tensor,
+                v: torch.Tensor,
+                j: torch.Tensor,
+                step_size: torch.Tensor,
+                neg_log_prob_target: callable,
+                log_prob_x: torch.Tensor,
+                max_delta: float) -> ParallelTreeState:
+    """
+    Build a balanced binary tree.
+    A separate tree is built individually for each chain state via vectorization.
+
+    :param torch.Tensor x: position tensor with shape `(n_chains, *event_shape)`.
+    :param torch.Tensor p: momentum tensor with shape `(n_chains, *event_shape)`.
+    :param Union[torch.Size, Tuple[int, ...]] event_shape: shape of the position and momentum tensors.
+    :param torch.Tensor u_slice: slice variable tensor with shape `(n_chains,)`.
+    :param torch.Tensor v: direction tensor with shape `(n_chains,)`.
+    :param torch.Tensor j: tree depth tensor with shape `(n_chains,)`.
+    :param torch.Tensor step_size: step size tensor with shape `(n_chains,)`.
+    :param callable neg_log_prob_target: negative log probability density function. 
+        Takes as input an event tensor with shape `(n_chains, *event_shape)` and outputs 
+        a negative log probability tensor with shape `(n_chains,)`.
+    :param torch.Tensor log_prob_x: log probability density of incoming position tensor x with shape `(n_chains,)`.
+    :param float max_delta: energy error divergence threshold.
+    """
+
+    # Clone position and momentum tensors
+    state = ParallelTreeState(
+        n_chains=x.shape[0],
+        event_shape=event_shape
+    )
+
+    base_case_mask = (j == 0)
+    general_case_mask = (j > 0)
+
+    # Base case
+    if base_case_mask.any():
+        # Perform a single leapfrog step
+        x1, p1, neg_log_prob1, g1 = leapfrog_step(
+            x=x[base_case_mask],
+            momentum=p[base_case_mask],
+            event_shape=event_shape,
+            step_size=v[base_case_mask] * step_size[base_case_mask],
+            neg_log_prob_target=neg_log_prob_target,
+            return_neg_log_prob_and_grad=True
+        )
+        log_prob1 = -neg_log_prob1
+
+        joint = log_prob1 - _kinetic_energy(p1)
+        diverged = ((joint - log_prob_x[base_case_mask])
+                    < -max_delta) | (~torch.isfinite(log_prob1))
+        valid = (torch.log(u_slice) <= joint) & (
+            ~diverged) & torch.isfinite(log_prob1)
+
+        state.x_minus[base_case_mask], state.p_minus[base_case_mask] = x1, p1
+        state.x_plus[base_case_mask], state.p_plus[base_case_mask] = x1, p1
+        state.x_prime[base_case_mask], state.log_prob_prime[base_case_mask] = x1, log_prob1
+
+        state.n_valid[base_case_mask][valid] = 1
+        # Redundant, but kept for safety
+        state.n_valid[base_case_mask][~valid] = 0
+        state.sum_accept_prob[base_case_mask] = _acceptance_prob(
+            log_prob1,
+            p1,
+            log_prob_x[base_case_mask],
+            p[base_case_mask]
+        )
+        state.n_leapfrogs[base_case_mask] = 1
+        state.stop[base_case_mask] = diverged
+        state.diverged[base_case_mask] = diverged
+
+    # General case
+    if general_case_mask.any():
+        # Build the left subtree
+        left = _build_tree(
+            x=x[general_case_mask],
+            p=p[general_case_mask],
+            event_shape=event_shape,
+            u_slice=u_slice[general_case_mask],
+            v=v[general_case_mask],
+            j=j[general_case_mask] - 1,
+            step_size=step_size[general_case_mask],
+            neg_log_prob_target=neg_log_prob_target,
+            log_prob_x=log_prob_x[general_case_mask],
+            max_delta=max_delta
+        )
+
+        # Early stop if left diverged or told to stop
+        state_left_stop = left.masked_copy(left.stop)
+        stop_copy_mask = general_case_mask.clone()
+        stop_copy_mask[general_case_mask] = left.stop
+        state.overwrite_with(state_left_stop, stop_copy_mask)
+
+        state_left_continue = left.masked_copy(~left.stop)
+
+        negative_mask = (v == -1)
+        positive_mask = ~negative_mask
+
+        x_start, p_start = x.clone(), p.clone()
+        x_start[negative_mask], p_start[negative_mask] = state_left_continue.x_minus, state_left_continue.p_minus
+        x_start[positive_mask], p_start[positive_mask] = state_left_continue.x_plus, state_left_continue.p_plus
+
+        right = _build_tree(
+            x=x_start,
+            p=p_start,
+            event_shape=event_shape,
+            u_slice=u_slice[~left.stop],
+            v=v[~left.stop],
+            j=j[~left.stop] - 1,
+            step_size=step_size[~left.stop],
+            neg_log_prob_target=neg_log_prob_target,
+            log_prob_x=log_prob_x[~left.stop],
+            max_delta=max_delta
+        )
+
+        # Combine
+        ...
+
+        # Choose a proposal uniformly from valid points
+        state.n_valid = left.n_valid + right.n_valid
+        valid_mask = state.n_valid > 0
+
+        # If1
+        rand_mask = torch.less(
+            torch.rand((state.n_chains,)),
+            right.n_valid / state.n_valid
+        )
+
+        # If2
+        state.x_prime[rand_mask], state.log_prob_prime[rand_mask] = right.x_prime[rand_mask], right.log_prob_prime[rand_mask]
+        # Else2
+        state[~rand_mask], state.log_prob_prime[~rand_mask] = left.x_prime[~rand_mask], left.log_prob_prime[~rand_mask]
+        # Endif2
+
+        # Else1
+        state.x_prime[~valid_mask], state.log_prob_prime[~valid_mask] = left.x_prime[~valid_mask], left.log_prob_prime[~valid_mask]
+        # EndIf1
+
+    state.sum_accept_prob = left.sum_accept_prob + right.sum_accept_prob
+    state.n_leapfrogs = left.n_leapfrogs + right.n_leapfrogs
+    state.diverged = left.diverged | right.diverged
+
+    state.stop = right.stop | is_uturn(
+        left.x_minus,
+        right.x_plus,
+        left.p_minus,
+        right.p_plus
+    )
+
+    return state
+
+
+class NUTSKernel(MarkovKernel):
+    """
+    Implementation of the no-U-turn sampler (NUTS) transition kernel.
+    """
+
+    def __init__(self,
+                 event_shape: Union[Tuple[int, ...], torch.Size],
+                 neg_log_prob_target: callable,
+                 max_tree_depth: int = 10,
+                 max_delta: float = 1000.0,
+                 **kwargs):
+        """
+        NUTSKernel constructor.
+
+        :param Union[Tuple[int, ...], torch.Size] event_shape: shape of the event tensor.
+        :param callable neg_log_prob_target: negative log probability density function. 
+         Takes as input an event tensor with shape `(n_chains, *event_shape)` and outputs 
+         a negative log probability tensor with shape `(n_chains,)`.
+        :param int max_tree_depth: maximum depth of the balanced binary tree.
+        :param float max_delta: maximum allowed value of the Hamiltonian dynamics energy error.
+         If the simulated trajectory error exceeds this threshold, it is flagged as having diverged.
+        """
+        super().__init__(event_shape, neg_log_prob_target, **kwargs)
+        self.max_tree_depth = max_tree_depth
+        self.max_delta = max_delta
+
+    @property
+    def name(self):
+        return 'NUTS'
+
+    def step(self,
+             x: torch.Tensor,
+             update: bool = False) -> torch.Tensor:
+        """
+        Perform one NUTS transition.
+
+        :param torch.Tensor x: incoming state tensor with shape `(*batch_shape, *event_shape)`.
+        :param bool update: if True, update kernel parameters.
+        :return: new state tensor with shape `(*batch_shape, *event_shape)`.
+        """
+        if self.warmup_active:
+            step_size = self._dual_averaging.value
+        else:
+            step_size = self.step_size
+
+        log_prob = -self.neg_log_prob_target(x)
+
+        # Sample momentum and slice variable
+        p0 = torch.randn_like(x)
+        joint0 = float(log_prob - _kinetic_energy(p0))
+        u_slice = torch.rand(()) * math.exp(joint0)
+
+        # Initialize balanced binary tree
+        x_minus, x_plus = x.clone(), x.clone()
+        p_minus, p_plus = p0.clone(), p0.clone()
+        x_prime = x.clone()
+        log_prob_prime = log_prob.clone()
+
+        for j in range(self.max_tree_depth + 1):
+            # Choose direction
+            if torch.randint(0, 2, ()).item() == 1:
+                v = 1
+            else:
+                v = -1
+
+            if v == -1:
+                # Build tree into negative time direction
+                state: TreeState = _build_tree()
+                x_minus, p_minus = state.x_minus, state.p_minus
+            else:
+                # Build tree into positive time direction
+                state: TreeState = _build_tree()
+                x_plus, p_plus = state.x_plus, state.p_plus
+
+            # Select state among valid states
+
+            pass
+
+        # Accept proposal
+
+        # Sample momentum and simulate trajectory
+        x_prime, p_prime, nc, ng = hmc_trajectory(
+            x=x.clone(),
+            momentum=p,
+            event_shape=self.event_shape,
+            step_size=step_size,
+            n_leapfrog_steps=self.n_leapfrog_steps,
+            neg_log_prob_target=self.neg_log_prob_target
+        )
+        self.increment_n_calls(nc)
+        self.increment_n_grads(ng)
+
+        # Compute divergence mask
+        divergence_mask_x = compute_divergence_mask(x_prime, self.event_shape)
+        divergence_mask_p = compute_divergence_mask(p_prime, self.event_shape)
+        divergence_mask = divergence_mask_x | divergence_mask_p
+
+        n_valid_proposals = int((~divergence_mask).long().sum())
+        self.increment_n_divergences(int(divergence_mask.long().sum()))
+
+        # Compute acceptance mask
+        acceptance_mask = torch.zeros_like(divergence_mask)
+        if n_valid_proposals > 0:
+            hamiltonian_start: torch.Tensor = (
+                self.neg_log_prob_target(x[~divergence_mask])
+                + 0.5 * sum_except_batch(
+                    p[~divergence_mask] ** 2,
+                    self.event_shape
+                )
+            )
+            self.increment_n_calls(n_valid_proposals)
+
+            hamiltonian_end: torch.Tensor = (
+                self.neg_log_prob_target(x_prime[~divergence_mask])
+                + 0.5 * sum_except_batch(
+                    p_prime[~divergence_mask] ** 2,
+                    self.event_shape
+                )
+            )
+            self.increment_n_calls(n_valid_proposals)
+
+            log_prob_accept = -hamiltonian_end - (-hamiltonian_start)
+            log_u = torch.rand_like(log_prob_accept).log()
+            acceptance_mask[~divergence_mask] = (log_u < log_prob_accept)
+        x[acceptance_mask] = x_prime[acceptance_mask].clone()
+        x = x.detach().clone()
+
+        if update:
+            self._update(acceptance_mask)
+
+        self.increment_n_steps()
+        self.increment_n_attempted_transitions(n_chains=x.shape[0])
+        self.increment_n_accepted_transitions(
+            int(acceptance_mask.long().sum()))
+
+        return x

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -52,6 +52,18 @@ class ParallelTreeState:
         self.stop = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
         self.diverged = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
         self.n_leapfrogs = torch.zeros(size=(self.n_chains,), dtype=torch.long)
+    
+    def to(self, tensor: torch.Tensor):
+        self.x_minus = self.x_minus.to(tensor)
+        self.x_plus = self.x_plus.to(tensor)
+        
+        self.p_minus = self.p_minus.to(tensor)
+        self.p_plus = self.p_plus.to(tensor)
+
+        self.x_prime = self.x_prime.to(tensor)
+        self.log_prob_prime = self.log_prob_prime.to(tensor)
+
+        return self
 
     def masked_copy(self, mask: torch.Tensor):
         """
@@ -60,14 +72,14 @@ class ParallelTreeState:
         return ParallelTreeState(
             n_chains=int(mask.sum()),
             event_shape=self.event_shape,
-            x_minus=self.x_minus[mask].clone(),
-            x_plus=self.x_plus[mask].clone(),
+            x_minus=self.x_minus[mask].clone().to(self.x_minus),
+            x_plus=self.x_plus[mask].clone().to(self.x_plus),
 
-            p_minus=self.p_minus[mask].clone(),
-            p_plus=self.p_plus[mask].clone(),
+            p_minus=self.p_minus[mask].clone().to(self.p_minus),
+            p_plus=self.p_plus[mask].clone().to(self.p_plus),
 
-            x_prime=self.x_prime[mask].clone(),
-            log_prob_prime=self.log_prob_prime[mask].clone(),
+            x_prime=self.x_prime[mask].clone().to(self.x_prime),
+            log_prob_prime=self.log_prob_prime[mask].clone().to(self.log_prob_prime),
 
             n_valid=self.n_valid[mask].clone(),
             sum_accept_prob=self.sum_accept_prob[mask].clone(),
@@ -86,14 +98,14 @@ class ParallelTreeState:
             raise ValueError(
                 f"Shape of overwrite mask should be equal to {(self.n_chains,)}, but got {mask.shape}"
             )
-        self.x_minus[mask] = other_state.x_minus
-        self.x_plus[mask] = other_state.x_plus
+        self.x_minus[mask] = other_state.x_minus.to(self.x_minus)
+        self.x_plus[mask] = other_state.x_plus.to(self.x_plus)
 
-        self.p_minus[mask] = other_state.p_minus
-        self.p_plus[mask] = other_state.p_plus
+        self.p_minus[mask] = other_state.p_minus.to(self.p_minus)
+        self.p_plus[mask] = other_state.p_plus.to(self.p_plus)
 
-        self.x_prime[mask] = other_state.x_prime
-        self.log_prob_prime[mask] = other_state.log_prob_prime
+        self.x_prime[mask] = other_state.x_prime.to(self.x_prime)
+        self.log_prob_prime[mask] = other_state.log_prob_prime.to(self.log_prob_prime)
         self.n_valid[mask] = other_state.n_valid
         self.sum_accept_prob[mask] = other_state.sum_accept_prob
         self.stop[mask] = other_state.stop
@@ -114,10 +126,11 @@ def _acceptance_prob(log_prob_new,
 def is_uturn(x_minus,
              x_plus,
              p_minus,
-             p_plus):
+             p_plus,
+             event_shape):
     dx = x_plus - x_minus
-    m1 = torch.einsum('...i,...j->...', dx, p_minus) < 0
-    m2 = torch.einsum('...i,...j->...', dx, p_plus) < 0
+    m1 = sum_except_batch(dx * p_minus, event_shape) < 0
+    m2 = sum_except_batch(dx * p_plus, event_shape) < 0
     return m1 | m2
 
 
@@ -153,10 +166,15 @@ def _build_tree(x: torch.Tensor,
     state = ParallelTreeState(
         n_chains=x.shape[0],
         event_shape=event_shape
-    )
+    ).to(x)
 
     m_b = (j == 0)  # Base case mask
     m_g = (j > 0)   # General case mask
+
+    if torch.any(j < 0):
+        raise ValueError("Incorrect tree depth")
+    if torch.numel(j) == 0:
+        raise ValueError("Zero chains in recursive call")
 
     # Base case
     if m_b.any():
@@ -198,7 +216,7 @@ def _build_tree(x: torch.Tensor,
         return state, nc, ng
 
     # General case
-    if m_g.any():
+    elif m_g.any():
         # Build the left subtree (`n_g` chains)
         left, nc_left, ng_left = _build_tree(
             x=x[m_g],
@@ -225,6 +243,10 @@ def _build_tree(x: torch.Tensor,
         # Overwrite the early-stopped chains in the main state
         state.overwrite_with(left_early, m_g_early)
         m_g_non_early = ~m_g_early  # Mask for non-early-stopped chains
+
+        if not m_g_non_early.any():
+            return left, nc_left, ng_left
+
         left_continue = left.masked_copy(m_g_non_early)
 
         # (`n_g_c` chains)
@@ -261,37 +283,17 @@ def _build_tree(x: torch.Tensor,
         )
 
         # Combine
-        (
-            state.x_minus[m_g_non_early][m_g_non_early_negative],
-            state.x_minus[m_g_non_early][m_g_non_early_positive]
-        ) = (
-            left_continue.x_minus[m_g_non_early_negative],
-            right.x_minus[m_g_non_early_positive]
-        )
+        # > Left (non early stopped)
+        state.x_minus[m_g_non_early][m_g_non_early_negative] = left_continue.x_minus[m_g_non_early_negative]
+        state.p_minus[m_g_non_early][m_g_non_early_negative] = left_continue.p_minus[m_g_non_early_negative]
+        state.x_plus[m_g_non_early][m_g_non_early_negative] = left_continue.x_plus[m_g_non_early_negative]
+        state.p_plus[m_g_non_early][m_g_non_early_negative] = left_continue.p_plus[m_g_non_early_negative]
 
-        (
-            state.p_minus[m_g_non_early][m_g_non_early_negative],
-            state.p_minus[m_g_non_early][m_g_non_early_positive]
-        ) = (
-            left_continue.p_minus[m_g_non_early_negative],
-            right.p_minus[m_g_non_early_positive]
-        )
-
-        (
-            state.x_plus[m_g_non_early][m_g_non_early_negative],
-            state.x_plus[m_g_non_early][m_g_non_early_positive]
-        ) = (
-            left_continue.x_plus[m_g_non_early_negative],
-            right.x_plus[m_g_non_early_positive]
-        )
-
-        (
-            state.p_plus[m_g_non_early][m_g_non_early_negative],
-            state.p_plus[m_g_non_early][m_g_non_early_positive]
-        ) = (
-            left_continue.p_plus[m_g_non_early_negative],
-            right.p_plus[m_g_non_early_positive]
-        )
+        # Right
+        state.x_minus[m_g_non_early][m_g_non_early_positive] = right.x_minus[m_g_non_early_positive]
+        state.p_minus[m_g_non_early][m_g_non_early_positive] = right.p_minus[m_g_non_early_positive]
+        state.x_plus[m_g_non_early][m_g_non_early_positive] = right.x_plus[m_g_non_early_positive]
+        state.p_plus[m_g_non_early][m_g_non_early_positive] = right.p_plus[m_g_non_early_positive]
 
         # Choose a proposal uniformly from valid points
         state.n_valid[m_g_non_early] = left_continue.n_valid + right.n_valid
@@ -345,11 +347,13 @@ def _build_tree(x: torch.Tensor,
             left_continue.x_minus,
             right.x_plus,
             left_continue.p_minus,
-            right.p_plus
+            right.p_plus,
+            event_shape=event_shape
         )
 
         return state, nc_left + nc_right, ng_left + ng_right
-
+    else:
+        raise ValueError("Recursion did not use base or general case in any chain")
 
 class NUTSKernel(LocalMHKernel):
     """
@@ -404,12 +408,12 @@ class NUTSKernel(LocalMHKernel):
                 step_size = torch.full(
                     size=(n_chains,), fill_value=step_size.item())
 
-        log_prob_x = -self.neg_log_prob_target(x)
+        log_prob_x = -self.neg_log_prob_target(x).to(x)
 
         # Sample momentum and slice variable
         p0 = torch.randn_like(x)
         joint0 = log_prob_x - _kinetic_energy(p0, self.event_shape)
-        u_slice = torch.rand_like(step_size) * torch.exp(joint0)
+        u_slice = torch.rand_like(step_size).to(x) * torch.exp(joint0).to(x)
 
         # Initialize balanced binary tree
         x_minus, x_plus = x.clone(), x.clone()
@@ -443,7 +447,7 @@ class NUTSKernel(LocalMHKernel):
                 event_shape=self.event_shape,
                 u_slice=u_slice,
                 v=v,
-                j=torch.full(size=(n_chains,), fill_value=j),
+                j=torch.full(size=(n_chains,), fill_value=j, dtype=torch.long),
                 step_size=step_size,
                 neg_log_prob_target=self.neg_log_prob_target,
                 log_prob_x=log_prob_x,
@@ -470,10 +474,9 @@ class NUTSKernel(LocalMHKernel):
             diverged[state.diverged] = True
 
             # Update state (select state among valid states)
-            m_update = (
-                state.n_valid > 0
-                & (torch.rand(size=(n_chains,)) < (state.n_valid / (n_valid + state.n_valid)))
-            )
+            _rand = torch.rand(size=(n_chains,)).to(x)
+            _thresh = state.n_valid / (n_valid + state.n_valid)
+            m_update = (state.n_valid > 0) & (_rand < _thresh)
             x_prime[m_update] = state.x_prime[m_update].clone()
             log_prob_x_prime[m_update] = state.log_prob_prime[m_update].clone()
 
@@ -488,6 +491,7 @@ class NUTSKernel(LocalMHKernel):
                 x_plus=x_plus,
                 p_minus=p_minus,
                 p_plus=p_plus,
+                event_shape=self.event_shape,
             ).all():
                 break
 

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -302,23 +302,23 @@ def _build_tree(x: torch.Tensor,
             left_continue = left.masked_copy(m_g_non_early)
 
             # (`n_g_c` chains)
-            m_g_non_early_negative = (v[m_g_non_early] == -1)
-            m_g_non_early_positive = ~m_g_non_early_negative
+            m_g_negative = (v[m_g] == -1)
+            m_g_positive = ~m_g_negative
 
             x_start, p_start = x.clone(), p.clone()  # (`n` chains)
             (
-                x_start[m_g_non_early & m_g_non_early_negative],
-                p_start[m_g_non_early & m_g_non_early_negative]
+                x_start[m_g_non_early & m_g_negative],
+                p_start[m_g_non_early & m_g_negative]
             ) = (
-                left_continue.x_minus[m_g_non_early_negative],
-                left_continue.p_minus[m_g_non_early_negative]
+                left_continue.x_minus[m_g_negative[m_g_non_early]],
+                left_continue.p_minus[m_g_negative[m_g_non_early]]
             )
             (
-                x_start[m_g_non_early & m_g_non_early_positive],
-                p_start[m_g_non_early & m_g_non_early_positive]
+                x_start[m_g_non_early & m_g_positive],
+                p_start[m_g_non_early & m_g_positive]
             ) = (
-                left_continue.x_plus[m_g_non_early_positive],
-                left_continue.p_plus[m_g_non_early_positive]
+                left_continue.x_plus[m_g_positive[m_g_non_early]],
+                left_continue.p_plus[m_g_positive[m_g_non_early]]
             )
 
             right, nc_right, ng_right = _build_tree(
@@ -336,39 +336,47 @@ def _build_tree(x: torch.Tensor,
 
             # Combine
             # > Left (non early stopped)
-            state.x_minus[m_g_non_early & m_g_non_early_negative] = left_continue.x_minus[m_g_non_early_negative]
-            state.p_minus[m_g_non_early & m_g_non_early_negative] = left_continue.p_minus[m_g_non_early_negative]
-            state.x_plus[m_g_non_early & m_g_non_early_negative] = left_continue.x_plus[m_g_non_early_negative]
-            state.p_plus[m_g_non_early & m_g_non_early_negative] = left_continue.p_plus[m_g_non_early_negative]
+            state.x_minus[m_g_non_early & m_g_negative] = left_continue.x_minus[m_g_negative[m_g_non_early]]
+            state.p_minus[m_g_non_early & m_g_negative] = left_continue.p_minus[m_g_negative[m_g_non_early]]
+            state.x_plus[m_g_non_early & m_g_negative] = left_continue.x_plus[m_g_negative[m_g_non_early]]
+            state.p_plus[m_g_non_early & m_g_negative] = left_continue.p_plus[m_g_negative[m_g_non_early]]
 
             # Right
-            state.x_minus[m_g_non_early & m_g_non_early_positive] = right.x_minus[m_g_non_early_positive]
-            state.p_minus[m_g_non_early & m_g_non_early_positive] = right.p_minus[m_g_non_early_positive]
-            state.x_plus[m_g_non_early & m_g_non_early_positive] = right.x_plus[m_g_non_early_positive]
-            state.p_plus[m_g_non_early & m_g_non_early_positive] = right.p_plus[m_g_non_early_positive]
+            state.x_minus[m_g_non_early & m_g_positive] = right.x_minus[m_g_positive[m_g_non_early]]
+            state.p_minus[m_g_non_early & m_g_positive] = right.p_minus[m_g_positive[m_g_non_early]]
+            state.x_plus[m_g_non_early & m_g_positive] = right.x_plus[m_g_positive[m_g_non_early]]
+            state.p_plus[m_g_non_early & m_g_positive] = right.p_plus[m_g_positive[m_g_non_early]]
 
             # Set proposed position
             # If1
-            n_remaining_chains = int(m_g_non_early.long().sum())
-            _thresh = (right.n_prime.float()) / (left.n_prime.float() + right.n_prime.float())
-            _rand = torch.rand((n_remaining_chains,), dtype=x.dtype)
+            n_non_early_chains = int(m_g_non_early.long().sum())
+            _thresh = (right.n_prime.float()) / (left_continue.n_prime.float() + right.n_prime.float())
+            _rand = torch.rand((n_non_early_chains,), dtype=x.dtype)
             rand_mask = _rand < _thresh
+            
+            set_idx_dst_pos = torch.arange(n_chains)
+            set_idx_dst_pos = set_idx_dst_pos[m_g_non_early]
+            set_idx_dst_pos = set_idx_dst_pos[rand_mask]
+
+            set_idx_dst_neg = torch.arange(n_chains)
+            set_idx_dst_neg = set_idx_dst_neg[m_g_non_early]
+            set_idx_dst_neg = set_idx_dst_neg[~rand_mask]
 
             # If2
             (
-                state.x_prime[m_g_non_early & rand_mask],
-                state.log_prob_prime[m_g_non_early & rand_mask]
+                state.x_prime[set_idx_dst_pos],
+                state.log_prob_prime[set_idx_dst_pos]
             ) = (
                 right.x_prime[rand_mask],
                 right.log_prob_prime[rand_mask]
             )
             # Else2
             (
-                state.x_prime[m_g_non_early & (~rand_mask)],
-                state.log_prob_prime[m_g_non_early & (~rand_mask)]
+                state.x_prime[set_idx_dst_neg],
+                state.log_prob_prime[set_idx_dst_neg]
             ) = (
-                left_continue.x_prime[~rand_mask],
-                left_continue.log_prob_prime[~rand_mask]
+                left_continue.x_prime[(~rand_mask)],
+                left_continue.log_prob_prime[(~rand_mask)]
             )
             # Endif2
 
@@ -495,9 +503,9 @@ class NUTSKernel(LocalMHKernel):
             m_neg = (v == -1)
 
             _x_build_tree = x_plus[_active_mask]
-            _x_build_tree[m_neg] = x_minus[_active_mask & m_neg]
+            _x_build_tree[m_neg] = x_minus[_active_mask][m_neg]
             _p_build_tree = p_plus[_active_mask]
-            _p_build_tree[m_neg] = p_minus[_active_mask & m_neg]
+            _p_build_tree[m_neg] = p_minus[_active_mask][m_neg]
 
             half_tree, nc, ng = _build_tree(
                 x=_x_build_tree,
@@ -514,17 +522,25 @@ class NUTSKernel(LocalMHKernel):
             half_tree: ParallelTreeState
             self.increment_n_divergences(int(half_tree.diverged.long().sum()))
 
+            set_idx_dst_pos = torch.arange(n_chains)
+            set_idx_dst_pos = set_idx_dst_pos[_active_mask]
+            set_idx_dst_pos = set_idx_dst_pos[~m_neg]
+
+            set_idx_dst_neg = torch.arange(n_chains)
+            set_idx_dst_neg = set_idx_dst_neg[_active_mask]
+            set_idx_dst_neg = set_idx_dst_neg[m_neg]
+
             (
-                x_minus[_active_mask & m_neg],
-                p_minus[_active_mask & m_neg]
+                x_minus[set_idx_dst_neg],
+                p_minus[set_idx_dst_neg]
             ) = (
                 half_tree.x_minus[m_neg],
                 half_tree.p_minus[m_neg]
             )
 
             (
-                x_plus[_active_mask & (~m_neg)],
-                p_plus[_active_mask & (~m_neg)]
+                x_plus[set_idx_dst_pos],
+                p_plus[set_idx_dst_pos]
             ) = (
                 half_tree.x_plus[~m_neg],
                 half_tree.p_plus[~m_neg]
@@ -535,8 +551,13 @@ class NUTSKernel(LocalMHKernel):
             _rand = torch.rand_like(step_size[_active_mask])
             _thresh = half_tree.n_prime.to(_rand.dtype) / n[_active_mask].to(_rand.dtype)
             m_update = (_rand < _thresh)
-            x_prime[_active_mask & m_update] = half_tree.x_prime[m_update].clone()
-            log_prob_x_prime[_active_mask & m_update] = half_tree.log_prob_prime[m_update].clone()
+
+            set_idx_dst_update = torch.arange(n_chains)
+            set_idx_dst_update = set_idx_dst_update[_active_mask]
+            set_idx_dst_update = set_idx_dst_update[m_update]
+
+            x_prime[set_idx_dst_update] = half_tree.x_prime[m_update].clone()
+            log_prob_x_prime[set_idx_dst_update] = half_tree.log_prob_prime[m_update].clone()
 
             n[_active_mask] += half_tree.n_prime
             alpha[_active_mask] += half_tree.alpha_prime

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -105,9 +105,10 @@ class ParallelTreeState:
 def _acceptance_prob(log_prob_new,
                      momentum_new,
                      log_prob_old,
-                     momentum_old):
-    h_new = -log_prob_new + _kinetic_energy(momentum_new)
-    h_old = -log_prob_old + _kinetic_energy(momentum_old)
+                     momentum_old,
+                     event_shape):
+    h_new = -log_prob_new + _kinetic_energy(momentum_new, event_shape)
+    h_old = -log_prob_old + _kinetic_energy(momentum_old, event_shape)
     return torch.clamp(torch.exp(h_old-h_new), max=1.0)
 
 
@@ -155,124 +156,200 @@ def _build_tree(x: torch.Tensor,
         event_shape=event_shape
     )
 
-    base_case_mask = (j == 0)
-    general_case_mask = (j > 0)
+    m_b = (j == 0)  # Base case mask
+    m_g = (j > 0)   # General case mask
 
     # Base case
-    if base_case_mask.any():
+    if m_b.any():
         # Perform a single leapfrog step
-        x1, p1, neg_log_prob1, g1 = leapfrog_step(
-            x=x[base_case_mask],
-            momentum=p[base_case_mask],
+        x1, p1, _, _, neg_log_prob1, g1 = leapfrog_step(
+            x=x[m_b],
+            momentum=p[m_b],
             event_shape=event_shape,
-            step_size=v[base_case_mask] * step_size[base_case_mask],
+            step_size=v[m_b] * step_size[m_b],
             neg_log_prob_target=neg_log_prob_target,
             return_neg_log_prob_and_grad=True
         )
         log_prob1 = -neg_log_prob1
 
-        joint = log_prob1 - _kinetic_energy(p1)
-        diverged = ((joint - log_prob_x[base_case_mask])
+        joint = log_prob1 - _kinetic_energy(p1, event_shape)
+        diverged = ((joint - log_prob_x[m_b])
                     < -max_delta) | (~torch.isfinite(log_prob1))
-        valid = (torch.log(u_slice) <= joint) & (
+        valid_b = (torch.log(u_slice[m_b]) <= joint) & (
             ~diverged) & torch.isfinite(log_prob1)
 
-        state.x_minus[base_case_mask], state.p_minus[base_case_mask] = x1, p1
-        state.x_plus[base_case_mask], state.p_plus[base_case_mask] = x1, p1
-        state.x_prime[base_case_mask], state.log_prob_prime[base_case_mask] = x1, log_prob1
+        state.x_minus[m_b], state.p_minus[m_b] = x1, p1
+        state.x_plus[m_b], state.p_plus[m_b] = x1, p1
+        state.x_prime[m_b], state.log_prob_prime[m_b] = x1, log_prob1
 
-        state.n_valid[base_case_mask][valid] = 1
+        state.n_valid[m_b][valid_b] = 1
         # Redundant, but kept for safety
-        state.n_valid[base_case_mask][~valid] = 0
-        state.sum_accept_prob[base_case_mask] = _acceptance_prob(
+        state.n_valid[m_b][~valid_b] = 0
+        state.sum_accept_prob[m_b] = _acceptance_prob(
             log_prob1,
             p1,
-            log_prob_x[base_case_mask],
-            p[base_case_mask]
+            log_prob_x[m_b],
+            p[m_b],
+            event_shape
         )
-        state.n_leapfrogs[base_case_mask] = 1
-        state.stop[base_case_mask] = diverged
-        state.diverged[base_case_mask] = diverged
+        state.n_leapfrogs[m_b] = 1
+        state.stop[m_b] = diverged
+        state.diverged[m_b] = diverged
+
+        return state
 
     # General case
-    if general_case_mask.any():
-        # Build the left subtree
+    if m_g.any():
+        # Build the left subtree (`n_g` chains)
         left = _build_tree(
-            x=x[general_case_mask],
-            p=p[general_case_mask],
+            x=x[m_g],
+            p=p[m_g],
             event_shape=event_shape,
-            u_slice=u_slice[general_case_mask],
-            v=v[general_case_mask],
-            j=j[general_case_mask] - 1,
-            step_size=step_size[general_case_mask],
+            u_slice=u_slice[m_g],
+            v=v[m_g],
+            j=j[m_g] - 1,
+            step_size=step_size[m_g],
             neg_log_prob_target=neg_log_prob_target,
-            log_prob_x=log_prob_x[general_case_mask],
+            log_prob_x=log_prob_x[m_g],
             max_delta=max_delta
         )
 
-        # Early stop if left diverged or told to stop
-        state_left_stop = left.masked_copy(left.stop)
-        stop_copy_mask = general_case_mask.clone()
-        stop_copy_mask[general_case_mask] = left.stop
-        state.overwrite_with(state_left_stop, stop_copy_mask)
+        # Split the left subtree according to early stopping:
+        # - left_early (`n_g_e` chains) is the tree with early stopping. For
+        #       chains where _  build_tree diverged or was told to stop, do not change
+        #       their subtree anymore. In the single-chain version, this would mean
+        #       returning the left subtree as is.
+        # - left_continue (`n_g_c` chains)
+        left_early = left.masked_copy(left.stop)
+        m_g_early = m_g.clone()  # Mask for early-stopped chains
+        m_g_early[m_g] = left.stop
+        # Overwrite the early-stopped chains in the main state
+        state.overwrite_with(left_early, m_g_early)
+        m_g_non_early = ~m_g_early  # Mask for non-early-stopped chains
+        left_continue = left.masked_copy(m_g_non_early)
 
-        state_left_continue = left.masked_copy(~left.stop)
+        # (`n_g_c` chains)
+        m_g_non_early_negative = (v[m_g_non_early] == -1)
+        m_g_non_early_positive = ~m_g_non_early_negative
 
-        negative_mask = (v == -1)
-        positive_mask = ~negative_mask
-
-        x_start, p_start = x.clone(), p.clone()
-        x_start[negative_mask], p_start[negative_mask] = state_left_continue.x_minus, state_left_continue.p_minus
-        x_start[positive_mask], p_start[positive_mask] = state_left_continue.x_plus, state_left_continue.p_plus
+        x_start, p_start = x.clone(), p.clone()  # (`n` chains)
+        (
+            x_start[m_g_non_early][m_g_non_early_negative],
+            p_start[m_g_non_early][m_g_non_early_negative]
+        ) = (
+            left_continue.x_minus[m_g_non_early_negative],
+            left_continue.p_minus[m_g_non_early_negative]
+        )
+        (
+            x_start[m_g_non_early][m_g_non_early_positive],
+            p_start[m_g_non_early][m_g_non_early_positive]
+        ) = (
+            left_continue.x_plus[m_g_non_early_positive],
+            left_continue.p_plus[m_g_non_early_positive]
+        )
 
         right = _build_tree(
-            x=x_start,
-            p=p_start,
+            x=x_start[m_g_non_early],
+            p=p_start[m_g_non_early],
             event_shape=event_shape,
-            u_slice=u_slice[~left.stop],
-            v=v[~left.stop],
-            j=j[~left.stop] - 1,
-            step_size=step_size[~left.stop],
+            u_slice=u_slice[m_g_non_early],
+            v=v[m_g_non_early],
+            j=j[m_g_non_early] - 1,
+            step_size=step_size[m_g_non_early],
             neg_log_prob_target=neg_log_prob_target,
-            log_prob_x=log_prob_x[~left.stop],
+            log_prob_x=log_prob_x[m_g_non_early],
             max_delta=max_delta
         )
 
         # Combine
-        ...
+        (
+            state.x_minus[m_g_non_early][m_g_non_early_negative],
+            state.x_minus[m_g_non_early][m_g_non_early_positive]
+        ) = (
+            left_continue.x_minus[m_g_non_early_negative],
+            right.x_minus[m_g_non_early_positive]
+        )
+
+        (
+            state.p_minus[m_g_non_early][m_g_non_early_negative],
+            state.p_minus[m_g_non_early][m_g_non_early_positive]
+        ) = (
+            left_continue.p_minus[m_g_non_early_negative],
+            right.p_minus[m_g_non_early_positive]
+        )
+
+        (
+            state.x_plus[m_g_non_early][m_g_non_early_negative],
+            state.x_plus[m_g_non_early][m_g_non_early_positive]
+        ) = (
+            left_continue.x_plus[m_g_non_early_negative],
+            right.x_plus[m_g_non_early_positive]
+        )
+
+        (
+            state.p_plus[m_g_non_early][m_g_non_early_negative],
+            state.p_plus[m_g_non_early][m_g_non_early_positive]
+        ) = (
+            left_continue.p_plus[m_g_non_early_negative],
+            right.p_plus[m_g_non_early_positive]
+        )
 
         # Choose a proposal uniformly from valid points
-        state.n_valid = left.n_valid + right.n_valid
-        valid_mask = state.n_valid > 0
+        state.n_valid[m_g_non_early] = left_continue.n_valid + right.n_valid
+        valid_g_non_early = state.n_valid[m_g_non_early] > 0  # (< n_g_c)
 
         # If1
         rand_mask = torch.less(
-            torch.rand((state.n_chains,)),
-            right.n_valid / state.n_valid
+            torch.rand(int(m_g_non_early.long().sum()),),
+            right.n_valid / state.n_valid[m_g_non_early]
         )
 
         # If2
-        state.x_prime[rand_mask], state.log_prob_prime[rand_mask] = right.x_prime[rand_mask], right.log_prob_prime[rand_mask]
+        (
+            state.x_prime[m_g_non_early][rand_mask],
+            state.log_prob_prime[m_g_non_early][rand_mask]
+        ) = (
+            right.x_prime[rand_mask],
+            right.log_prob_prime[rand_mask]
+        )
         # Else2
-        state[~rand_mask], state.log_prob_prime[~rand_mask] = left.x_prime[~rand_mask], left.log_prob_prime[~rand_mask]
+        (
+            state.x_prime[m_g_non_early][~rand_mask],
+            state.log_prob_prime[m_g_non_early][~rand_mask]
+        ) = (
+            left_continue.x_prime[~rand_mask],
+            left_continue.log_prob_prime[~rand_mask]
+        )
         # Endif2
 
         # Else1
-        state.x_prime[~valid_mask], state.log_prob_prime[~valid_mask] = left.x_prime[~valid_mask], left.log_prob_prime[~valid_mask]
+        (
+            state.x_prime[m_g_non_early][~valid_g_non_early],
+            state.log_prob_prime[m_g_non_early][~valid_g_non_early]
+        ) = (
+            left_continue.x_prime[left_continue.n_valid == 0],
+            left_continue.log_prob_prime[left_continue.n_valid == 0]
+        )
         # EndIf1
 
-    state.sum_accept_prob = left.sum_accept_prob + right.sum_accept_prob
-    state.n_leapfrogs = left.n_leapfrogs + right.n_leapfrogs
-    state.diverged = left.diverged | right.diverged
+        state.sum_accept_prob[m_g_non_early] = (
+            left_continue.sum_accept_prob
+            + right.sum_accept_prob
+        )
+        state.n_leapfrogs[m_g_non_early] = (
+            left_continue.n_leapfrogs
+            + right.n_leapfrogs
+        )
+        state.diverged[m_g_non_early] = left_continue.diverged | right.diverged
 
-    state.stop = right.stop | is_uturn(
-        left.x_minus,
-        right.x_plus,
-        left.p_minus,
-        right.p_plus
-    )
+        state.stop[m_g_non_early] = right.stop | is_uturn(
+            left_continue.x_minus,
+            right.x_plus,
+            left_continue.p_minus,
+            right.p_plus
+        )
 
-    return state
+        return state
 
 
 class NUTSKernel(MarkovKernel):
@@ -324,7 +401,7 @@ class NUTSKernel(MarkovKernel):
 
         # Sample momentum and slice variable
         p0 = torch.randn_like(x)
-        joint0 = float(log_prob - _kinetic_energy(p0))
+        joint0 = float(log_prob - _kinetic_energy(p0, self.event_shape))
         u_slice = torch.rand(()) * math.exp(joint0)
 
         # Initialize balanced binary tree
@@ -342,11 +419,11 @@ class NUTSKernel(MarkovKernel):
 
             if v == -1:
                 # Build tree into negative time direction
-                state: TreeState = _build_tree()
+                state: ParallelTreeState = _build_tree()
                 x_minus, p_minus = state.x_minus, state.p_minus
             else:
                 # Build tree into positive time direction
-                state: TreeState = _build_tree()
+                state: ParallelTreeState = _build_tree()
                 x_plus, p_plus = state.x_plus, state.p_plus
 
             # Select state among valid states

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -34,9 +34,9 @@ class ParallelTreeState:
     s_prime: torch.Tensor = None
     n_prime: torch.Tensor = None
 
-    sum_accept_prob: torch.Tensor = None
+    alpha_prime: torch.Tensor = None
     diverged: torch.Tensor = None
-    n_leapfrogs: torch.Tensor = None
+    n_alpha_prime: torch.Tensor = None
 
     def __post_init__(self):
         # Position
@@ -85,8 +85,8 @@ class ParallelTreeState:
         if self.n_prime is None:
             self.n_prime = torch.zeros(size=(self.n_chains,), dtype=torch.long)
 
-        if self.sum_accept_prob is None:
-            self.sum_accept_prob = torch.zeros(size=(self.n_chains,))
+        if self.alpha_prime is None:
+            self.alpha_prime = torch.zeros(size=(self.n_chains,))
 
         if self.diverged is None:
             self.diverged = torch.zeros(
@@ -94,8 +94,8 @@ class ParallelTreeState:
                 dtype=torch.bool
             )
 
-        if self.n_leapfrogs is None:
-            self.n_leapfrogs = torch.zeros(
+        if self.n_alpha_prime is None:
+            self.n_alpha_prime = torch.zeros(
                 size=(self.n_chains,), 
                 dtype=torch.long
             )
@@ -119,9 +119,9 @@ class ParallelTreeState:
             s_prime=self.s_prime[mask],
             n_prime=self.n_prime[mask],
 
-            sum_accept_prob=self.sum_accept_prob[mask],
+            alpha_prime=self.alpha_prime[mask],
             diverged=self.diverged[mask],
-            n_leapfrogs=self.n_leapfrogs[mask],
+            n_alpha_prime=self.n_alpha_prime[mask],
         )
 
     def overwrite_with(self, other_state, mask: torch.Tensor):
@@ -134,6 +134,8 @@ class ParallelTreeState:
             raise ValueError(
                 f"Shape of overwrite mask should be equal to {(self.n_chains,)}, but got {mask.shape}"
             )
+        other_state: ParallelTreeState
+
         self.x_minus[mask] = other_state.x_minus
         self.x_plus[mask] = other_state.x_plus
 
@@ -146,9 +148,9 @@ class ParallelTreeState:
         self.s_prime[mask] = other_state.s_prime  # True: trajecory should continue
         self.n_prime[mask] = other_state.n_prime
 
-        self.sum_accept_prob[mask] = other_state.sum_accept_prob
+        self.alpha_prime[mask] = other_state.alpha_prime
         self.diverged[mask] = other_state.diverged
-        self.n_leapfrogs[mask] = other_state.n_leapfrogs
+        self.n_alpha_prime[mask] = other_state.n_alpha_prime
 
 
 def _acceptance_prob(log_prob_new,
@@ -253,14 +255,14 @@ def _build_tree(x: torch.Tensor,
         state.diverged[m_b] = ~torch.isfinite(joint)
 
         # Set other
-        state.sum_accept_prob[m_b] = _acceptance_prob(
+        state.alpha_prime[m_b] = _acceptance_prob(
             log_prob1,
             p1,
             log_prob_x[m_b],
             p[m_b],
             event_shape
-        ).to(state.sum_accept_prob.dtype)
-        state.n_leapfrogs[m_b] = 1
+        ).to(state.alpha_prime.dtype)
+        state.n_alpha_prime[m_b] = 1
 
         nc += nc_b
         ng += ng_b
@@ -382,20 +384,19 @@ def _build_tree(x: torch.Tensor,
             )
             state.n_prime[m_g_non_early] = left_continue.n_prime + right.n_prime
 
-            state.sum_accept_prob[m_g_non_early] = (
-                left_continue.sum_accept_prob
-                + right.sum_accept_prob
+            state.alpha_prime[m_g_non_early] = (
+                left_continue.alpha_prime
+                + right.alpha_prime
             )
-            state.n_leapfrogs[m_g_non_early] = (
-                left_continue.n_leapfrogs
-                + right.n_leapfrogs
+            state.n_alpha_prime[m_g_non_early] = (
+                left_continue.n_alpha_prime
+                + right.n_alpha_prime
             )
             state.diverged[m_g_non_early] = left_continue.diverged | right.diverged
 
             nc += nc_right
             ng += ng_right
 
-    assert torch.all(torch.isfinite(state.x_minus))
     return state, nc, ng
     
 
@@ -478,8 +479,8 @@ class NUTSKernel(LocalMHKernel):
         stop = torch.zeros(size=(n_chains,), dtype=torch.bool)  # ~s_prime
         n = torch.ones(size=(n_chains,), dtype=torch.long)
 
-        sum_accept = torch.zeros(size=(n_chains,))
-        n_lf_total = torch.zeros(size=(n_chains,), dtype=torch.long)
+        alpha = torch.zeros(size=(n_chains,))
+        n_alpha = torch.zeros(size=(n_chains,), dtype=torch.long)
 
         for j in range(self.max_tree_depth + 1):
             _active_mask = ~stop
@@ -538,15 +539,15 @@ class NUTSKernel(LocalMHKernel):
             log_prob_x_prime[_active_mask & m_update] = half_tree.log_prob_prime[m_update].clone()
 
             n[_active_mask] += half_tree.n_prime
-            sum_accept[_active_mask] += half_tree.sum_accept_prob
-            n_lf_total[_active_mask] += half_tree.n_leapfrogs
+            alpha[_active_mask] += half_tree.alpha_prime
+            n_alpha[_active_mask] += half_tree.n_alpha_prime
 
             if stop.all():
                 break
 
         # Dual averaging statistic
         if update:
-            h_da = sum_accept / torch.clip(n_lf_total, max=torch.tensor(1.0))
+            h_da = self._target_acceptance_rate - alpha / n_alpha.to(alpha.dtype)
             self._update(h_da)
 
         self.increment_n_calls(nc)

--- a/nfmc/algorithms/nuts.py
+++ b/nfmc/algorithms/nuts.py
@@ -31,47 +31,74 @@ class ParallelTreeState:
     log_prob_prime: torch.Tensor = None
 
     # Other variables
-    n_valid: torch.Tensor = None
+    s_prime: torch.Tensor = None
+    n_prime: torch.Tensor = None
+
     sum_accept_prob: torch.Tensor = None
-    stop: torch.Tensor = None
     diverged: torch.Tensor = None
     n_leapfrogs: torch.Tensor = None
 
     def __post_init__(self):
+        # Position
         if self.x_minus is None:
-            self.x_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
+            self.x_minus = torch.full(
+                size=(self.n_chains, *self.event_shape),
+                fill_value=torch.nan,
+            )
 
         if self.x_plus is None:
-            self.x_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
+            self.x_plus = torch.full(
+                size=(self.n_chains, *self.event_shape),
+                fill_value=torch.nan,
+            )
 
+        # Momentum
         if self.p_minus is None:
-            self.p_minus = torch.zeros(size=(self.n_chains, *self.event_shape))
+            self.p_minus = torch.full(
+                size=(self.n_chains, *self.event_shape),
+                fill_value=torch.nan,
+            )
 
         if self.p_plus is None:
-            self.p_plus = torch.zeros(size=(self.n_chains, *self.event_shape))
+            self.p_plus = torch.full(
+                size=(self.n_chains, *self.event_shape),
+                fill_value=torch.nan,
+            )
 
+        # Proposed state
         if self.x_prime is None:
-            self.x_prime = torch.zeros(size=(self.n_chains, *self.event_shape))
+            self.x_prime = torch.full(
+                size=(self.n_chains, *self.event_shape),
+                fill_value=torch.nan,
+            )
 
         if self.log_prob_prime is None:
-            self.log_prob_prime = torch.zeros(size=(self.n_chains,))
+            self.log_prob_prime = torch.full(
+                size=(self.n_chains,),
+                fill_value=torch.nan,
+            )
 
-        if self.n_valid is None:
-            self.n_valid = torch.zeros(size=(self.n_chains,), dtype=torch.long)
+        # Other
+        if self.s_prime is None:
+            self.s_prime = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
+        
+        if self.n_prime is None:
+            self.n_prime = torch.zeros(size=(self.n_chains,), dtype=torch.long)
 
         if self.sum_accept_prob is None:
             self.sum_accept_prob = torch.zeros(size=(self.n_chains,))
 
-        if self.stop is None:
-            self.stop = torch.zeros(size=(self.n_chains,), dtype=torch.bool)
-
         if self.diverged is None:
             self.diverged = torch.zeros(
-                size=(self.n_chains,), dtype=torch.bool)
+                size=(self.n_chains,), 
+                dtype=torch.bool
+            )
 
         if self.n_leapfrogs is None:
             self.n_leapfrogs = torch.zeros(
-                size=(self.n_chains,), dtype=torch.long)
+                size=(self.n_chains,), 
+                dtype=torch.long
+            )
 
     def masked_copy(self, mask: torch.Tensor):
         """
@@ -89,9 +116,10 @@ class ParallelTreeState:
             x_prime=self.x_prime[mask],
             log_prob_prime=self.log_prob_prime[mask],
 
-            n_valid=self.n_valid[mask],
+            s_prime=self.s_prime[mask],
+            n_prime=self.n_prime[mask],
+
             sum_accept_prob=self.sum_accept_prob[mask],
-            stop=self.stop[mask],
             diverged=self.diverged[mask],
             n_leapfrogs=self.n_leapfrogs[mask],
         )
@@ -114,9 +142,11 @@ class ParallelTreeState:
 
         self.x_prime[mask] = other_state.x_prime
         self.log_prob_prime[mask] = other_state.log_prob_prime
-        self.n_valid[mask] = other_state.n_valid
+
+        self.s_prime[mask] = other_state.s_prime  # True: trajecory should continue
+        self.n_prime[mask] = other_state.n_prime
+
         self.sum_accept_prob[mask] = other_state.sum_accept_prob
-        self.stop[mask] = other_state.stop
         self.diverged[mask] = other_state.diverged
         self.n_leapfrogs[mask] = other_state.n_leapfrogs
 
@@ -199,29 +229,30 @@ def _build_tree(x: torch.Tensor,
     # Base case
     if m_b.any():
         # Perform a single leapfrog step
-        x1, p1, nc_b, ng_b, neg_log_prob1, g1 = leapfrog_step(
-            x=x[m_b],
-            momentum=p[m_b],
+        x1, p1, nc_b, ng_b, neg_log_prob1, _ = leapfrog_step(
+            x=x[m_b].clone(),
+            momentum=p[m_b].clone(),
             event_shape=event_shape,
             step_size=v[m_b] * step_size[m_b],
             neg_log_prob_target=neg_log_prob_target,
             return_neg_log_prob_and_grad=True
         )
         log_prob1 = -neg_log_prob1
-
         joint = log_prob1 - _kinetic_energy(p1, event_shape)
-        diverged = ((joint - log_prob_x[m_b])
-                    < -max_delta) | (~torch.isfinite(log_prob1))
-        valid_b = (torch.log(u_slice[m_b]) <= joint) & (
-            ~diverged) & torch.isfinite(log_prob1)
 
+        # Set position and momentum
         state.x_minus[m_b], state.p_minus[m_b] = x1, p1
         state.x_plus[m_b], state.p_plus[m_b] = x1, p1
+
+        # Set proposed state
         state.x_prime[m_b], state.log_prob_prime[m_b] = x1, log_prob1
 
-        state.n_valid[m_b][valid_b] = 1
-        # Redundant, but kept for safety
-        state.n_valid[m_b][~valid_b] = 0
+        # Set divergence variables
+        state.n_prime[m_b] = (torch.log(u_slice[m_b]) <= joint).long()
+        state.s_prime[m_b] = (torch.log(u_slice[m_b]) - max_delta < joint)
+        state.diverged[m_b] = ~torch.isfinite(joint)
+
+        # Set other
         state.sum_accept_prob[m_b] = _acceptance_prob(
             log_prob1,
             p1,
@@ -230,8 +261,6 @@ def _build_tree(x: torch.Tensor,
             event_shape
         ).to(state.sum_accept_prob.dtype)
         state.n_leapfrogs[m_b] = 1
-        state.stop[m_b] = diverged
-        state.diverged[m_b] = diverged
 
         nc += nc_b
         ng += ng_b
@@ -260,9 +289,9 @@ def _build_tree(x: torch.Tensor,
         #       their subtree anymore. In the single-chain version, this would mean
         #       returning the left subtree as is.
         # - left_continue (`n_g_c` chains)
-        left_early = left.masked_copy(left.stop)
+        left_early = left.masked_copy(~left.s_prime)
         m_g_early = m_g.clone()  # Mask for early-stopped chains
-        m_g_early[m_g] = left.stop
+        m_g_early[m_g] = ~left.s_prime
         # Overwrite the early-stopped chains in the main state
         state.overwrite_with(left_early, m_g_early)
         m_g_non_early = ~m_g_early  # Mask for non-early-stopped chains
@@ -276,15 +305,15 @@ def _build_tree(x: torch.Tensor,
 
             x_start, p_start = x.clone(), p.clone()  # (`n` chains)
             (
-                x_start[m_g_non_early][m_g_non_early_negative],
-                p_start[m_g_non_early][m_g_non_early_negative]
+                x_start[m_g_non_early & m_g_non_early_negative],
+                p_start[m_g_non_early & m_g_non_early_negative]
             ) = (
                 left_continue.x_minus[m_g_non_early_negative],
                 left_continue.p_minus[m_g_non_early_negative]
             )
             (
-                x_start[m_g_non_early][m_g_non_early_positive],
-                p_start[m_g_non_early][m_g_non_early_positive]
+                x_start[m_g_non_early & m_g_non_early_positive],
+                p_start[m_g_non_early & m_g_non_early_positive]
             ) = (
                 left_continue.x_plus[m_g_non_early_positive],
                 left_continue.p_plus[m_g_non_early_positive]
@@ -305,53 +334,53 @@ def _build_tree(x: torch.Tensor,
 
             # Combine
             # > Left (non early stopped)
-            state.x_minus[m_g_non_early][m_g_non_early_negative] = left_continue.x_minus[m_g_non_early_negative]
-            state.p_minus[m_g_non_early][m_g_non_early_negative] = left_continue.p_minus[m_g_non_early_negative]
-            state.x_plus[m_g_non_early][m_g_non_early_negative] = left_continue.x_plus[m_g_non_early_negative]
-            state.p_plus[m_g_non_early][m_g_non_early_negative] = left_continue.p_plus[m_g_non_early_negative]
+            state.x_minus[m_g_non_early & m_g_non_early_negative] = left_continue.x_minus[m_g_non_early_negative]
+            state.p_minus[m_g_non_early & m_g_non_early_negative] = left_continue.p_minus[m_g_non_early_negative]
+            state.x_plus[m_g_non_early & m_g_non_early_negative] = left_continue.x_plus[m_g_non_early_negative]
+            state.p_plus[m_g_non_early & m_g_non_early_negative] = left_continue.p_plus[m_g_non_early_negative]
 
             # Right
-            state.x_minus[m_g_non_early][m_g_non_early_positive] = right.x_minus[m_g_non_early_positive]
-            state.p_minus[m_g_non_early][m_g_non_early_positive] = right.p_minus[m_g_non_early_positive]
-            state.x_plus[m_g_non_early][m_g_non_early_positive] = right.x_plus[m_g_non_early_positive]
-            state.p_plus[m_g_non_early][m_g_non_early_positive] = right.p_plus[m_g_non_early_positive]
+            state.x_minus[m_g_non_early & m_g_non_early_positive] = right.x_minus[m_g_non_early_positive]
+            state.p_minus[m_g_non_early & m_g_non_early_positive] = right.p_minus[m_g_non_early_positive]
+            state.x_plus[m_g_non_early & m_g_non_early_positive] = right.x_plus[m_g_non_early_positive]
+            state.p_plus[m_g_non_early & m_g_non_early_positive] = right.p_plus[m_g_non_early_positive]
 
-            # Choose a proposal uniformly from valid points
-            state.n_valid[m_g_non_early] = left_continue.n_valid + right.n_valid
-            valid_g_non_early = state.n_valid[m_g_non_early] > 0  # (< n_g_c)
-
+            # Set proposed position
             # If1
-            _rand = torch.rand((int(m_g_non_early.long().sum()),), dtype=x.dtype)
-            _thresh = right.n_valid / state.n_valid[m_g_non_early]
+            n_remaining_chains = int(m_g_non_early.long().sum())
+            _thresh = (right.n_prime.float()) / (left.n_prime.float() + right.n_prime.float())
+            _rand = torch.rand((n_remaining_chains,), dtype=x.dtype)
             rand_mask = _rand < _thresh
 
             # If2
             (
-                state.x_prime[m_g_non_early][rand_mask],
-                state.log_prob_prime[m_g_non_early][rand_mask]
+                state.x_prime[m_g_non_early & rand_mask],
+                state.log_prob_prime[m_g_non_early & rand_mask]
             ) = (
                 right.x_prime[rand_mask],
                 right.log_prob_prime[rand_mask]
             )
             # Else2
             (
-                state.x_prime[m_g_non_early][~rand_mask],
-                state.log_prob_prime[m_g_non_early][~rand_mask]
+                state.x_prime[m_g_non_early & (~rand_mask)],
+                state.log_prob_prime[m_g_non_early & (~rand_mask)]
             ) = (
                 left_continue.x_prime[~rand_mask],
                 left_continue.log_prob_prime[~rand_mask]
             )
             # Endif2
 
-            # Else1
-            (
-                state.x_prime[m_g_non_early][~valid_g_non_early],
-                state.log_prob_prime[m_g_non_early][~valid_g_non_early]
-            ) = (
-                left_continue.x_prime[left_continue.n_valid == 0],
-                left_continue.log_prob_prime[left_continue.n_valid == 0]
+            state.s_prime[m_g_non_early] = (
+                right.s_prime
+                & (~is_uturn(
+                    state.x_minus[m_g_non_early],
+                    state.x_plus[m_g_non_early],
+                    state.p_minus[m_g_non_early],
+                    state.p_plus[m_g_non_early],
+                    event_shape=event_shape
+                ))
             )
-            # EndIf1
+            state.n_prime[m_g_non_early] = left_continue.n_prime + right.n_prime
 
             state.sum_accept_prob[m_g_non_early] = (
                 left_continue.sum_accept_prob
@@ -363,17 +392,10 @@ def _build_tree(x: torch.Tensor,
             )
             state.diverged[m_g_non_early] = left_continue.diverged | right.diverged
 
-            state.stop[m_g_non_early] = right.stop | is_uturn(
-                left_continue.x_minus,
-                right.x_plus,
-                left_continue.p_minus,
-                right.p_plus,
-                event_shape=event_shape
-            )
-
             nc += nc_right
             ng += ng_right
 
+    assert torch.all(torch.isfinite(state.x_minus))
     return state, nc, ng
     
 
@@ -418,6 +440,7 @@ class NUTSKernel(LocalMHKernel):
         :param bool update: if True, update kernel parameters.
         :return: new state tensor with shape `(*batch_shape, *event_shape)`.
         """
+        x = x.clone()
         n_chains = x.shape[0]
 
         # Choose step size according to warmup flag
@@ -452,83 +475,74 @@ class NUTSKernel(LocalMHKernel):
         log_prob_x_prime = log_prob_x.clone()
 
         # Initialize other variables
-        n_valid = torch.zeros(size=(n_chains,), dtype=torch.long)
+        stop = torch.zeros(size=(n_chains,), dtype=torch.bool)  # ~s_prime
+        n = torch.ones(size=(n_chains,), dtype=torch.long)
+
         sum_accept = torch.zeros(size=(n_chains,))
         n_lf_total = torch.zeros(size=(n_chains,), dtype=torch.long)
-        stop = torch.zeros(size=(n_chains,), dtype=torch.bool)
-        diverged = torch.zeros(size=(n_chains,), dtype=torch.bool)
 
         for j in range(self.max_tree_depth + 1):
+            _active_mask = ~stop
+            _n_active = int(torch.sum(_active_mask.long()))
+
             # Choose direction
-            _r = torch.randint(size=(n_chains,), low=0, high=2).to(step_size.dtype)
+            _r = torch.randint(size=(_n_active,), low=0, high=2).to(step_size.dtype)
             v = _r * 2 - 1
 
             # Build tree into negative/positive time directions
             # (determined according to v within _build_tree)
             m_neg = (v == -1)
 
-            _x_build_tree = x_plus.clone()
-            _x_build_tree[m_neg] = x_minus[m_neg]
-            _p_build_tree = p_plus.clone()
-            _p_build_tree[m_neg] = p_minus[m_neg]
+            _x_build_tree = x_plus[_active_mask]
+            _x_build_tree[m_neg] = x_minus[_active_mask & m_neg]
+            _p_build_tree = p_plus[_active_mask]
+            _p_build_tree[m_neg] = p_minus[_active_mask & m_neg]
 
-            state, nc, ng = _build_tree(
+            half_tree, nc, ng = _build_tree(
                 x=_x_build_tree,
                 p=_p_build_tree,
                 event_shape=self.event_shape,
-                u_slice=u_slice,
+                u_slice=u_slice[_active_mask],
                 v=v,
-                j=torch.full(size=(n_chains,), fill_value=j, dtype=torch.long),
-                step_size=step_size,
+                j=torch.full(size=(_n_active,), fill_value=j, dtype=torch.long),
+                step_size=step_size[_active_mask],
                 neg_log_prob_target=self.neg_log_prob_target,
-                log_prob_x=log_prob_x,
+                log_prob_x=log_prob_x[_active_mask],
                 max_delta=self.max_delta
             )
-            state: ParallelTreeState
+            half_tree: ParallelTreeState
+            self.increment_n_divergences(int(half_tree.diverged.long().sum()))
 
             (
-                x_minus[m_neg],
-                p_minus[m_neg]
+                x_minus[_active_mask & m_neg],
+                p_minus[_active_mask & m_neg]
             ) = (
-                state.x_minus[m_neg],
-                state.p_minus[m_neg]
+                half_tree.x_minus[m_neg],
+                half_tree.p_minus[m_neg]
             )
 
             (
-                x_plus[~m_neg],
-                p_plus[~m_neg]
+                x_plus[_active_mask & (~m_neg)],
+                p_plus[_active_mask & (~m_neg)]
             ) = (
-                state.x_plus[~m_neg],
-                state.p_plus[~m_neg]
+                half_tree.x_plus[~m_neg],
+                half_tree.p_plus[~m_neg]
             )
-            stop[state.stop] = True
-            diverged[state.diverged] = True
+            stop[_active_mask] |= (~half_tree.s_prime) | half_tree.diverged
 
             # Update state (select state among valid states)
-            _rand = torch.rand_like(step_size)
-            _thresh = state.n_valid / (n_valid + state.n_valid)
-            m_update = (state.n_valid > 0) & (_rand < _thresh)
-            x_prime[m_update] = state.x_prime[m_update]
-            log_prob_x_prime[m_update] = state.log_prob_prime[m_update]
+            _rand = torch.rand_like(step_size[_active_mask])
+            _thresh = half_tree.n_prime.to(_rand.dtype) / n[_active_mask].to(_rand.dtype)
+            m_update = (_rand < _thresh)
+            x_prime[_active_mask & m_update] = half_tree.x_prime[m_update].clone()
+            log_prob_x_prime[_active_mask & m_update] = half_tree.log_prob_prime[m_update].clone()
 
-            n_valid += state.n_valid
-            sum_accept += state.sum_accept_prob
-            n_lf_total += state.n_leapfrogs
+            n[_active_mask] += half_tree.n_prime
+            sum_accept[_active_mask] += half_tree.sum_accept_prob
+            n_lf_total[_active_mask] += half_tree.n_leapfrogs
 
             if stop.all():
                 break
-            if is_uturn(
-                x_minus=x_minus,
-                x_plus=x_plus,
-                p_minus=p_minus,
-                p_plus=p_plus,
-                event_shape=self.event_shape,
-            ).all():
-                break
-
-        # Accept proposal
-        x = x_prime
-        log_prob_x = log_prob_x_prime
 
         # Dual averaging statistic
         if update:
@@ -537,12 +551,11 @@ class NUTSKernel(LocalMHKernel):
 
         self.increment_n_calls(nc)
         self.increment_n_grads(ng)
-        self.increment_n_divergences(int(state.diverged.long().sum()))
         self.increment_n_steps()
         self.increment_n_attempted_transitions(n_chains=n_chains)
         self.increment_n_accepted_transitions(n_chains)
 
-        return x
+        return x_prime
 
     def _update(self, h: torch.Tensor):
         """
@@ -552,3 +565,18 @@ class NUTSKernel(LocalMHKernel):
         """
         self._dual_averaging.step(h)
         self.step_size = torch.mean(self._dual_averaging.value)
+
+    def pbar_repr(self, elapsed_time_seconds: float):
+        eps_mean = torch.mean(torch.as_tensor(self._dual_averaging.error_sum))
+        eps_max = torch.max(torch.as_tensor(self._dual_averaging.error_sum))
+        eps_min = torch.min(torch.as_tensor(self._dual_averaging.error_sum))
+        data = [
+            self.name,
+            f'log step: {torch.log(self.step_size):.3f}',
+            f'DA[{eps_mean:.2f} ^{eps_max:.2f} v{eps_min:.2f}]',
+            f'{self.calls_per_second(elapsed_time_seconds):.3f} c/s',
+            f'{self.grads_per_second(elapsed_time_seconds):.3f} g/s',
+            f'{self.acceptance_rate:.3f} acc',
+            f'{self._n_divergences} divs'
+        ]
+        return ', '.join(data)

--- a/nfmc/algorithms/preconditioning/preconditioners.py
+++ b/nfmc/algorithms/preconditioning/preconditioners.py
@@ -157,11 +157,15 @@ class NormalizingFlowPreconditioner(Preconditioner):
         self.flow: Flow = flow
 
     def inverse_transform(self, z: torch.Tensor):
+        self.flow.train()
         x, log_det = self.flow.bijection.inverse(z)
+        self.flow.eval()
         return x, log_det
 
     def forward_transform(self, x: torch.Tensor):
+        self.flow.train()
         z, log_det = self.flow.bijection.forward(x)
+        self.flow.eval()
         return z, log_det
 
     def fit(self, x: torch.Tensor, **kwargs):

--- a/nfmc/algorithms/preconditioning/samplers/mixed.py
+++ b/nfmc/algorithms/preconditioning/samplers/mixed.py
@@ -48,6 +48,7 @@ class BinaryMixedPreconditionedMCMCSampler(PreconditionedMCMCSampler):
                max_samples: int = None,
                max_training_samples: int = None,
                data_transform: callable = None,
+               return_latent_samples: bool = False,
                **kwargs) -> Samples:
         """
         Optimize kernel parameters.
@@ -75,6 +76,10 @@ class BinaryMixedPreconditionedMCMCSampler(PreconditionedMCMCSampler):
             event_shape=self.kernel.event_shape,
             max_samples=max_samples,
             data_transform=data_transform
+        )        
+        latent_samples = Samples(
+            event_shape=self.kernel.event_shape,
+            max_samples=max_samples,
         )
 
         _adj_max = max_training_samples
@@ -118,6 +123,8 @@ class BinaryMixedPreconditionedMCMCSampler(PreconditionedMCMCSampler):
                 # final stage: always update
                 or step >= (n_steps - preconditioner_update_interval)
             )
+
+            z = self.kernel._preconditioner.forward_transform(x)[0]
             _, x = self.kernel.step_with_preconditioner_inverse(
                 z,
                 update=do_update

--- a/nfmc/sample.py
+++ b/nfmc/sample.py
@@ -9,12 +9,13 @@ from nfmc.algorithms.mh.local.hmc import HMCKernel
 from nfmc.algorithms.mh.local.mala import MALAKernel
 from nfmc.algorithms.mh.local.rwmh import RWMHKernel
 
+from nfmc.algorithms.nuts import NUTSKernel
 from nfmc.algorithms.preconditioning.preconditioners import NormalizingFlowPreconditioner
 from nfmc.algorithms.preconditioning.samplers.base import PreconditionedMCMCSampler
 
 from nfmc.algorithms.mh.imh import IMHKernel
 from nfmc.algorithms.iterated_sir import IteratedSIRKernel
-from nfmc.algorithms.jump.kernels import NeuTraJumpHMCKernel, NeuTraJumpMALAKernel, NeuTraJumpRWMHKernel
+from nfmc.algorithms.jump.kernels import NeuTraJumpHMCKernel, NeuTraJumpMALAKernel, NeuTraJumpNUTSKernel, NeuTraJumpRWMHKernel
 from nfmc.algorithms.base.sampler import MCMCSampler
 from nfmc.algorithms.util.samples import Samples
 from nfmc.util import create_flow_object
@@ -25,12 +26,15 @@ PRECONDITIONED_SAMPLERS = [
     "jump_hmc",
     "jump_mala",
     "jump_rwmh",
+    "jump_nuts",
     "neutra_hmc",
     "neutra_mala",
     "neutra_rwmh",
+    "neutra_nuts",
     "ex2_hmc",
     "ex2_mala",
     "ex2_rwmh",
+    "ex2_nuts",
 ]
 
 
@@ -77,10 +81,16 @@ def create_sampler(neg_log_prob_target: callable,
     elif hasattr(neg_log_prob_target, "event_shape"):
         event_shape = neg_log_prob_target.event_shape
 
-    if kernel in ['hmc', 'mala', 'rwmh']:
+    if kernel in ['hmc', 'mala', 'rwmh', 'nuts']:
         # MCMC
         if kernel == "hmc":
             kernel_object = HMCKernel(
+                event_shape=event_shape,
+                neg_log_prob_target=neg_log_prob_target,
+                **kernel_kwargs
+            )
+        elif kernel == "nuts":
+            kernel_object = NUTSKernel(
                 event_shape=event_shape,
                 neg_log_prob_target=neg_log_prob_target,
                 **kernel_kwargs
@@ -138,6 +148,13 @@ def create_sampler(neg_log_prob_target: callable,
                 global_kernel='imh',
                 **kernel_kwargs
             )
+        elif kernel == 'jump_nuts':
+            kernel_object = NeuTraJumpNUTSKernel(
+                flow=flow_object,
+                neg_log_prob_target=neg_log_prob_target,
+                global_kernel='imh',
+                **kernel_kwargs
+            )
         elif kernel == 'jump_mala':
             kernel_object = NeuTraJumpMALAKernel(
                 flow=flow_object,
@@ -159,6 +176,13 @@ def create_sampler(neg_log_prob_target: callable,
                 global_kernel='i-sir',
                 **kernel_kwargs
             )
+        elif kernel == 'ex2_nuts':
+            kernel_object = NeuTraJumpNUTSKernel(
+                flow=flow_object,
+                neg_log_prob_target=neg_log_prob_target,
+                global_kernel='i-sir',
+                **kernel_kwargs
+            )
         elif kernel == 'ex2_mala':
             kernel_object = NeuTraJumpMALAKernel(
                 flow=flow_object,
@@ -175,6 +199,15 @@ def create_sampler(neg_log_prob_target: callable,
             )
         elif kernel == 'neutra_hmc':
             kernel_object = HMCKernel(
+                event_shape=event_shape,
+                neg_log_prob_target=neg_log_prob_target,
+                preconditioner=NormalizingFlowPreconditioner(
+                    flow=flow_object
+                ),
+                **kernel_kwargs
+            )
+        elif kernel == 'neutra_nuts':
+            kernel_object = NUTSKernel(
                 event_shape=event_shape,
                 neg_log_prob_target=neg_log_prob_target,
                 preconditioner=NormalizingFlowPreconditioner(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+torchflows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+torch>=2.0.1
+numpy
+torchdiffeq
+tqdm
 torchflows

--- a/test/test_dual_averaging.py
+++ b/test/test_dual_averaging.py
@@ -59,6 +59,7 @@ def test_history(n_chains):
             assert len(torch.unique(da.step_size_history[i])) > 1
 
 
+@pytest.mark.local_only
 @pytest.mark.parametrize('kernel_class', [MALAKernel, RWMHKernel, HMCKernel])
 def test_reach_target_acceptance_rate(kernel_class):
     torch.manual_seed(0)
@@ -90,7 +91,7 @@ def test_reach_target_acceptance_rate(kernel_class):
         torch.Tensor
     )
 
-
+@pytest.mark.local_only
 @pytest.mark.parametrize('kernel_class', [MALAKernel, RWMHKernel])
 def test_persist_step_size(kernel_class):
     torch.manual_seed(0)

--- a/test/test_dual_averaging.py
+++ b/test/test_dual_averaging.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from nfmc.algorithms.mh.local.dual_averaging import DualAveraging
+from nfmc.algorithms.mh.local.hmc import HMCKernel
 from nfmc.algorithms.mh.local.mala import MALAKernel
 from nfmc.algorithms.mh.local.rwmh import RWMHKernel
 from nfmc.algorithms.mh.base import MHSampler
@@ -25,6 +26,7 @@ def test_step(n_chains):
     assert torch.isfinite(da.value).all()
     assert (da.value > 0).all()
     assert (da.value != initial_step_size).all()
+    assert da.value.shape == (n_chains,)
 
 
 @pytest.mark.parametrize('n_chains', [1, 2, 10])
@@ -57,7 +59,7 @@ def test_history(n_chains):
             assert len(torch.unique(da.step_size_history[i])) > 1
 
 
-@pytest.mark.parametrize('kernel_class', [MALAKernel, RWMHKernel])
+@pytest.mark.parametrize('kernel_class', [MALAKernel, RWMHKernel, HMCKernel])
 def test_reach_target_acceptance_rate(kernel_class):
     torch.manual_seed(0)
 

--- a/test/test_dual_averaging.py
+++ b/test/test_dual_averaging.py
@@ -13,13 +13,14 @@ from test.util import DiagonalGaussian
 @pytest.mark.parametrize('n_chains', [1, 2, 10])
 def test_step(n_chains):
     torch.manual_seed(0)
+    target_acceptance_rate = 0.5
 
     initial_step_size = 1.0
     da = DualAveraging(
         initial_step_size=initial_step_size,
-        target_acceptance_rate=0.5
     )
-    da.step(torch.rand(size=(n_chains,)) < 0.2)
+    h = target_acceptance_rate - torch.rand(size=(n_chains,))
+    da.step(h)
 
     assert torch.isfinite(da.value).all()
     assert (da.value > 0).all()
@@ -35,7 +36,6 @@ def test_history(n_chains):
 
     da = DualAveraging(
         initial_step_size=initial_step_size,
-        target_acceptance_rate=target_acc_rate,
         store_step_sizes=True,
         store_errors=True,
     )
@@ -43,7 +43,8 @@ def test_history(n_chains):
     n_steps = 50
 
     for _ in range(n_steps):
-        da.step(torch.rand(size=(n_chains,)) < target_acc_rate)
+        h = target_acc_rate - torch.rand(size=(n_chains,))
+        da.step(h)
 
     assert len(da.step_size_history) == n_steps
     assert len(da.error_history) == n_steps
@@ -65,11 +66,9 @@ def test_reach_target_acceptance_rate(kernel_class):
 
     target = DiagonalGaussian(event_shape)
     kernel = kernel_class(
-        event_shape, target.
-        neg_log_prob,
-        dual_averaging_kwargs=dict(
-            target_acceptance_rate=target_acc_rate
-        )
+        event_shape,
+        target.neg_log_prob,
+        target_acceptance_rate=target_acc_rate
     )
     sampler = MHSampler(kernel)
 
@@ -83,7 +82,7 @@ def test_reach_target_acceptance_rate(kernel_class):
         target_acc_rate,
         rel_tol=0.05
     )
-    
+
     assert isinstance(
         sampler.kernel.step_size,
         torch.Tensor
@@ -93,7 +92,7 @@ def test_reach_target_acceptance_rate(kernel_class):
 @pytest.mark.parametrize('kernel_class', [MALAKernel, RWMHKernel])
 def test_persist_step_size(kernel_class):
     torch.manual_seed(0)
-    
+
     target_acc_rate = 0.764321
     event_shape = (4,)
 
@@ -101,9 +100,7 @@ def test_persist_step_size(kernel_class):
     kernel = kernel_class(
         event_shape,
         target.neg_log_prob,
-        dual_averaging_kwargs=dict(
-            target_acceptance_rate=target_acc_rate
-        )
+        target_acceptance_rate=target_acc_rate
     )
     sampler = MHSampler(kernel)
 

--- a/test/test_local_mcmc.py
+++ b/test/test_local_mcmc.py
@@ -82,7 +82,6 @@ def test_sample(event_shape, kernel_class, n_chains, n_steps):
 @pytest.mark.parametrize('n_steps', [1, 4])
 def test_warmup(event_shape, kernel_class, n_chains, n_steps):
     torch.manual_seed(0)
-
     x_initial = torch.randn(size=(n_chains, *event_shape))
     kernel = kernel_class(
         event_shape=event_shape,
@@ -111,6 +110,16 @@ def test_warmup(event_shape, kernel_class, n_chains, n_steps):
 def test_warmup_and_sample(kernel_class):
     torch.manual_seed(0)
 
+    if kernel_class == HMCKernel:
+        n_warmup_steps = 200
+        n_sampling_steps = 2000
+    elif kernel_class == NUTSKernel:
+        n_warmup_steps = 50
+        n_sampling_steps = 200
+    else:
+        n_warmup_steps = 2000
+        n_sampling_steps = 2000
+
     event_shape = (4,)
     target = DiagonalGaussian(event_shape)
 
@@ -120,10 +129,11 @@ def test_warmup_and_sample(kernel_class):
     x0 = torch.rand(size=(1, *event_shape)) * 2 - 1
     warmup_draws = sampler.warmup(
         x0=x0,
-        n_steps=500 if kernel_class == HMCKernel else 2000
+        n_steps=n_warmup_steps
     )
     sampling_draws = sampler.sample(
-        x0=warmup_draws.last_sample, n_steps=2000
+        x0=warmup_draws.last_sample, 
+        n_steps=n_sampling_steps
     )
 
     assert torch.allclose(

--- a/test/test_local_mcmc.py
+++ b/test/test_local_mcmc.py
@@ -3,6 +3,7 @@ from nfmc.algorithms.mh.imh import IMHKernel
 from nfmc.algorithms.mh.local.hmc import HMCKernel
 from nfmc.algorithms.mh.local.mala import MALAKernel
 from nfmc.algorithms.mh.local.rwmh import RWMHKernel
+from nfmc.algorithms.nuts import NUTSKernel
 from nfmc.algorithms.util.samples import Samples
 from test.util import DiagonalGaussian, StandardGaussian
 
@@ -12,7 +13,13 @@ import torch
 
 
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
-@pytest.mark.parametrize('kernel_class', [RWMHKernel, HMCKernel, IMHKernel, MALAKernel])
+@pytest.mark.parametrize('kernel_class', [
+    RWMHKernel,
+    HMCKernel,
+    IMHKernel,  # add IMH
+    MALAKernel,
+    NUTSKernel
+])
 @pytest.mark.parametrize('n_chains', [1, 4])
 @pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
 def test_step(event_shape, kernel_class, n_chains, dtype):
@@ -34,7 +41,12 @@ def test_step(event_shape, kernel_class, n_chains, dtype):
 
 @pytest.mark.local_only
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
-@pytest.mark.parametrize('kernel_class', [RWMHKernel, HMCKernel, MALAKernel])
+@pytest.mark.parametrize('kernel_class', [
+    RWMHKernel,
+    HMCKernel,
+    MALAKernel,
+    NUTSKernel
+])
 @pytest.mark.parametrize('n_chains', [1, 4])
 @pytest.mark.parametrize('n_steps', [1, 4])
 def test_sample(event_shape, kernel_class, n_chains, n_steps):
@@ -60,7 +72,12 @@ def test_sample(event_shape, kernel_class, n_chains, n_steps):
 
 @pytest.mark.local_only
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
-@pytest.mark.parametrize('kernel_class', [RWMHKernel, HMCKernel, MALAKernel])
+@pytest.mark.parametrize('kernel_class', [
+    RWMHKernel,
+    HMCKernel,
+    MALAKernel,
+    NUTSKernel
+])
 @pytest.mark.parametrize('n_chains', [1, 4])
 @pytest.mark.parametrize('n_steps', [1, 4])
 def test_warmup(event_shape, kernel_class, n_chains, n_steps):
@@ -85,7 +102,12 @@ def test_warmup(event_shape, kernel_class, n_chains, n_steps):
 
 
 @pytest.mark.local_only
-@pytest.mark.parametrize("kernel_class", [RWMHKernel, MALAKernel, HMCKernel])
+@pytest.mark.parametrize("kernel_class", [
+    RWMHKernel,
+    MALAKernel,
+    HMCKernel,
+    NUTSKernel
+])
 def test_warmup_and_sample(kernel_class):
     torch.manual_seed(0)
 
@@ -97,7 +119,7 @@ def test_warmup_and_sample(kernel_class):
 
     x0 = torch.rand(size=(1, *event_shape)) * 2 - 1
     warmup_draws = sampler.warmup(
-        x0=x0, 
+        x0=x0,
         n_steps=500 if kernel_class == HMCKernel else 2000
     )
     sampling_draws = sampler.sample(

--- a/test/test_mixing_kernel.py
+++ b/test/test_mixing_kernel.py
@@ -10,6 +10,7 @@ from nfmc.algorithms.preconditioning.samplers.mixed import BinaryMixedPreconditi
 from test.util import StandardGaussian
 
 
+@pytest.mark.skip("Mixing kernels not supported yet")
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
 @pytest.mark.parametrize('kernel_class', [RWMHKernel, HMCKernel, IMHKernel, MALAKernel])
 @pytest.mark.parametrize('n_chains', [1, 4])
@@ -39,6 +40,7 @@ def test_step(event_shape, kernel_class, n_chains):
     assert x_current.dtype == x_new.dtype
 
 
+@pytest.mark.skip("Mixing kernels not supported yet")
 def test_set_selection_probabilities_valid():
     torch.manual_seed(0)
 
@@ -67,6 +69,7 @@ def test_set_selection_probabilities_valid():
     assert x_current.dtype == x_new.dtype
 
 
+@pytest.mark.skip("Mixing kernels not supported yet")
 def test_set_selection_probabilities_invalid():
     torch.manual_seed(0)
 
@@ -89,6 +92,7 @@ def test_set_selection_probabilities_invalid():
         mixing_kernel.set_selection_probabilities([0.3, 0.8])
 
 
+@pytest.mark.skip("Mixing kernels not supported yet")
 def test_set_selection_probabilities_invalid_length():
     torch.manual_seed(0)
 
@@ -108,6 +112,7 @@ def test_set_selection_probabilities_invalid_length():
 
     with pytest.raises(ValueError):
         mixing_kernel.set_selection_probabilities([0.3, 0.7, 0.1])
+
 
 @pytest.mark.skip(reason='Invalid method')
 def test_binary_mixed_preconditioned_sampler_adaptation():

--- a/test/test_nf_architectures.py
+++ b/test/test_nf_architectures.py
@@ -1,0 +1,51 @@
+import pytest
+import torch
+
+from nfmc.algorithms.preconditioning.samplers.neutra import NeuTraMALA, NeuTraRWMH
+from test.util import DiagonalGaussian
+
+from torchflows.flows import Flow
+from torchflows.architectures import ResFlow, RNODE, RealNVP
+
+
+@pytest.mark.local_only
+@pytest.mark.parametrize(
+    "sampler_class", [
+        NeuTraRWMH,
+        NeuTraMALA
+    ]
+)
+@pytest.mark.parametrize(
+    "flow_class", [
+        RealNVP,
+        ResFlow,
+        RNODE
+    ]
+)
+def test_warmup_and_sample_no_runtime_error(sampler_class,
+                                            flow_class):
+    torch.manual_seed(0)
+
+    event_shape = (2,)
+    n_chains = 10
+    target = DiagonalGaussian(event_shape, mu=1.5, std=0.5)
+
+    flow = Flow(flow_class(event_shape))
+    sampler = sampler_class(
+        flow=flow,
+        neg_log_prob_target=target.neg_log_prob
+    )
+
+    z0 = torch.rand(size=(n_chains, *event_shape)) * 2 - 1
+    _, latent_warmup_draws = sampler.warmup(
+        z0=z0,
+        n_cycles=5,
+        cycle_length=7,
+        return_latent_samples=True,
+        n_epochs=2
+    )
+
+    sampling_draws = sampler.sample(
+        z0=latent_warmup_draws.last_sample,
+        n_steps=3,
+    )

--- a/test/test_nuts.py
+++ b/test/test_nuts.py
@@ -53,9 +53,9 @@ def test_build_tree(n_chains, tree_depth, dtype):
     assert state.p_minus.shape == (n_chains, *event_shape)
     assert state.p_plus.shape == (n_chains, *event_shape)
 
-    assert state.sum_accept_prob.shape == (n_chains,)
+    assert state.alpha_prime.shape == (n_chains,)
     assert state.diverged.shape == (n_chains,)
-    assert state.n_leapfrogs.shape == (n_chains,)
+    assert state.n_alpha_prime.shape == (n_chains,)
 
     assert torch.isfinite(state.x_minus).all()
     assert torch.isfinite(state.x_plus).all()
@@ -64,9 +64,9 @@ def test_build_tree(n_chains, tree_depth, dtype):
     assert torch.isfinite(state.x_prime).all()
     assert torch.isfinite(state.log_prob_prime).all()
 
-    assert torch.isfinite(state.sum_accept_prob).all()
+    assert torch.isfinite(state.alpha_prime).all()
     assert torch.isfinite(state.diverged).all()
-    assert torch.isfinite(state.n_leapfrogs).all()
+    assert torch.isfinite(state.n_alpha_prime).all()
 
     assert torch.all(state.x_prime != x0)
 
@@ -116,9 +116,9 @@ def test_masked_copy_dtype(event_shape, n_chains, float_dtype):
     assert state.x_prime.dtype == state_copy.x_prime.dtype
     assert state.log_prob_prime.dtype == state_copy.log_prob_prime.dtype
 
-    assert state.sum_accept_prob.dtype == state_copy.sum_accept_prob.dtype
+    assert state.alpha_prime.dtype == state_copy.alpha_prime.dtype
     assert state.diverged.dtype == state_copy.diverged.dtype
-    assert state.n_leapfrogs.dtype == state_copy.n_leapfrogs.dtype
+    assert state.n_alpha_prime.dtype == state_copy.n_alpha_prime.dtype
 
 
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])

--- a/test/test_nuts.py
+++ b/test/test_nuts.py
@@ -78,12 +78,13 @@ def test_build_tree(n_chains, tree_depth):
 @pytest.mark.parametrize('n_chains', [1, 4])
 @pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
 def test_step(event_shape, n_chains, dtype):
+    # Error: type mismatches when using torch.float64
     torch.manual_seed(0)
 
     x_current = torch.randn(size=(n_chains, *event_shape), dtype=dtype)
     kernel = NUTSKernel(
         event_shape=event_shape,
-        neg_log_prob_target=StandardGaussian(event_shape).neg_log_prob
+        neg_log_prob_target=StandardGaussian(event_shape).neg_log_prob,
     )
     x_new = kernel.step(x_current)
 

--- a/test/test_nuts.py
+++ b/test/test_nuts.py
@@ -7,8 +7,9 @@ from test.util import StandardGaussian
 
 
 @pytest.mark.parametrize('n_chains', [1, 4, 20])
-@pytest.mark.parametrize('tree_depth', [0, 1, 4, 10])
-def test_build_tree(n_chains, tree_depth):
+@pytest.mark.parametrize('tree_depth', [0, 1, 4])
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_build_tree(n_chains, tree_depth, dtype):
     torch.manual_seed(0)
 
     event_shape = (4,)
@@ -19,15 +20,15 @@ def test_build_tree(n_chains, tree_depth):
     def neg_log_prob_target(_tensor):
         return sum_except_batch(_tensor ** 2, event_shape)
 
-    x0 = torch.randn(size=(n_chains, *event_shape))
-    p0 = torch.randn(size=(n_chains, *event_shape))
-    log_prob_x0 = -neg_log_prob_target(x0)
+    x0 = torch.randn(size=(n_chains, *event_shape), dtype=dtype)
+    p0 = torch.randn(size=(n_chains, *event_shape), dtype=dtype)
+    log_prob_x0 = -neg_log_prob_target(x0).to(x0)
     joint0 = log_prob_x0 - _kinetic_energy(p0, event_shape)
-    u_slice = torch.rand(size=(n_chains,)) * torch.exp(joint0)
+    u_slice = torch.rand(size=(n_chains,), dtype=dtype) * torch.exp(joint0)
 
     # {0, 1} -> {0, 2} -> {-1, 1}
     v = torch.randint(low=0, high=2, size=(n_chains,)) * 2 - 1
-    step_size = torch.rand(size=(n_chains,)) / 100
+    step_size = torch.rand(size=(n_chains,), dtype=dtype) / 100
     j = torch.full(size=(n_chains,), fill_value=tree_depth)
 
     state, _, _ = _build_tree(
@@ -75,16 +76,50 @@ def test_build_tree(n_chains, tree_depth):
 
 
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
+@pytest.mark.parametrize('n_chains', [4])
+@pytest.mark.parametrize('float_dtype', [torch.float32, torch.float64])
+def test_masked_copy_dtype(event_shape, n_chains, float_dtype):
+    state: ParallelTreeState = ParallelTreeState(
+        n_chains=n_chains,
+        event_shape=event_shape
+    )
+    state.x_minus = state.x_minus.to(float_dtype)
+    state.x_plus = state.x_plus.to(float_dtype)
+    state.p_minus = state.p_minus.to(float_dtype)
+    state.p_plus = state.p_plus.to(float_dtype)
+    state.x_prime = state.x_prime.to(float_dtype)
+    state.log_prob_prime = state.log_prob_prime.to(float_dtype)
+
+    mask = torch.tensor([False, False, True, True], dtype=torch.bool)
+    state_copy: ParallelTreeState = state.masked_copy(mask)
+
+    assert state.x_minus.dtype == state_copy.x_minus.dtype
+    assert state.x_plus.dtype == state_copy.x_plus.dtype
+
+    assert state.p_minus.dtype == state_copy.p_minus.dtype
+    assert state.p_plus.dtype == state_copy.p_plus.dtype
+
+    assert state.x_prime.dtype == state_copy.x_prime.dtype
+    assert state.log_prob_prime.dtype == state_copy.log_prob_prime.dtype
+
+    assert state.n_valid.dtype == state_copy.n_valid.dtype
+    assert state.sum_accept_prob.dtype == state_copy.sum_accept_prob.dtype
+    assert state.stop.dtype == state_copy.stop.dtype
+    assert state.diverged.dtype == state_copy.diverged.dtype
+    assert state.n_leapfrogs.dtype == state_copy.n_leapfrogs.dtype
+
+
+@pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
 @pytest.mark.parametrize('n_chains', [1, 4])
 @pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
 def test_step(event_shape, n_chains, dtype):
-    # Error: type mismatches when using torch.float64
     torch.manual_seed(0)
 
     x_current = torch.randn(size=(n_chains, *event_shape), dtype=dtype)
     kernel = NUTSKernel(
         event_shape=event_shape,
         neg_log_prob_target=StandardGaussian(event_shape).neg_log_prob,
+        max_tree_depth=5
     )
     x_new = kernel.step(x_current)
 

--- a/test/test_nuts.py
+++ b/test/test_nuts.py
@@ -53,9 +53,7 @@ def test_build_tree(n_chains, tree_depth, dtype):
     assert state.p_minus.shape == (n_chains, *event_shape)
     assert state.p_plus.shape == (n_chains, *event_shape)
 
-    assert state.n_valid.shape == (n_chains,)
     assert state.sum_accept_prob.shape == (n_chains,)
-    assert state.stop.shape == (n_chains,)
     assert state.diverged.shape == (n_chains,)
     assert state.n_leapfrogs.shape == (n_chains,)
 
@@ -66,13 +64,29 @@ def test_build_tree(n_chains, tree_depth, dtype):
     assert torch.isfinite(state.x_prime).all()
     assert torch.isfinite(state.log_prob_prime).all()
 
-    assert torch.isfinite(state.n_valid).all()
     assert torch.isfinite(state.sum_accept_prob).all()
-    assert torch.isfinite(state.stop).all()
     assert torch.isfinite(state.diverged).all()
     assert torch.isfinite(state.n_leapfrogs).all()
 
     assert torch.all(state.x_prime != x0)
+
+
+@pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
+@pytest.mark.parametrize('n_chains', [1, 4])
+def test_overwrite_with(event_shape, n_chains):
+    torch.manual_seed(0)
+    state = ParallelTreeState(
+        n_chains=n_chains,
+        event_shape=event_shape
+    )
+    left = ParallelTreeState(
+        n_chains=1,
+        event_shape=event_shape,
+        x_minus=torch.randn(size=(1, *event_shape))
+    )
+    mask = torch.tensor([True] + [False] * (n_chains - 1))
+    state.overwrite_with(left, mask)
+    assert torch.all(state.x_minus[0] == left.x_minus[0])
 
 
 @pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
@@ -102,9 +116,7 @@ def test_masked_copy_dtype(event_shape, n_chains, float_dtype):
     assert state.x_prime.dtype == state_copy.x_prime.dtype
     assert state.log_prob_prime.dtype == state_copy.log_prob_prime.dtype
 
-    assert state.n_valid.dtype == state_copy.n_valid.dtype
     assert state.sum_accept_prob.dtype == state_copy.sum_accept_prob.dtype
-    assert state.stop.dtype == state_copy.stop.dtype
     assert state.diverged.dtype == state_copy.diverged.dtype
     assert state.n_leapfrogs.dtype == state_copy.n_leapfrogs.dtype
 
@@ -128,3 +140,4 @@ def test_step(event_shape, n_chains, dtype):
     assert x_new.shape == x_current.shape
     assert torch.isfinite(x_new).all()
     assert x_current.dtype == x_new.dtype
+    assert torch.all(x_current != x_new)

--- a/test/test_nuts.py
+++ b/test/test_nuts.py
@@ -1,13 +1,16 @@
 import torch
-from nfmc.algorithms.nuts import _build_tree, _kinetic_energy, ParallelTreeState
+from nfmc.algorithms.nuts import NUTSKernel, _build_tree, _kinetic_energy, ParallelTreeState
 from nfmc.util import sum_except_batch
 import pytest
+
+from test.util import StandardGaussian
+
 
 @pytest.mark.parametrize('n_chains', [1, 4, 20])
 @pytest.mark.parametrize('tree_depth', [0, 1, 4, 10])
 def test_build_tree(n_chains, tree_depth):
     torch.manual_seed(0)
-    
+
     event_shape = (4,)
 
     # n_chains = 20
@@ -15,7 +18,7 @@ def test_build_tree(n_chains, tree_depth):
 
     def neg_log_prob_target(_tensor):
         return sum_except_batch(_tensor ** 2, event_shape)
-    
+
     x0 = torch.randn(size=(n_chains, *event_shape))
     p0 = torch.randn(size=(n_chains, *event_shape))
     log_prob_x0 = -neg_log_prob_target(x0)
@@ -27,7 +30,7 @@ def test_build_tree(n_chains, tree_depth):
     step_size = torch.rand(size=(n_chains,)) / 100
     j = torch.full(size=(n_chains,), fill_value=tree_depth)
 
-    state: ParallelTreeState = _build_tree(
+    state, _, _ = _build_tree(
         x=x0,
         p=p0,
         event_shape=event_shape,
@@ -39,7 +42,9 @@ def test_build_tree(n_chains, tree_depth):
         log_prob_x=log_prob_x0,
         max_delta=1000.0
     )
+    state: ParallelTreeState
 
+    assert isinstance(state, ParallelTreeState)
     assert state.n_chains == n_chains
     assert state.event_shape == event_shape
     assert state.x_minus.shape == (n_chains, *event_shape)
@@ -67,3 +72,23 @@ def test_build_tree(n_chains, tree_depth):
     assert torch.isfinite(state.n_leapfrogs).all()
 
     assert torch.all(state.x_prime != x0)
+
+
+@pytest.mark.parametrize('event_shape', [(1,), (4,), (2, 3)])
+@pytest.mark.parametrize('n_chains', [1, 4])
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_step(event_shape, n_chains, dtype):
+    torch.manual_seed(0)
+
+    x_current = torch.randn(size=(n_chains, *event_shape), dtype=dtype)
+    kernel = NUTSKernel(
+        event_shape=event_shape,
+        neg_log_prob_target=StandardGaussian(event_shape).neg_log_prob
+    )
+    x_new = kernel.step(x_current)
+
+    assert x_new is not x_current
+    assert not x_new.requires_grad
+    assert x_new.shape == x_current.shape
+    assert torch.isfinite(x_new).all()
+    assert x_current.dtype == x_new.dtype

--- a/test/test_nuts.py
+++ b/test/test_nuts.py
@@ -1,0 +1,69 @@
+import torch
+from nfmc.algorithms.nuts import _build_tree, _kinetic_energy, ParallelTreeState
+from nfmc.util import sum_except_batch
+import pytest
+
+@pytest.mark.parametrize('n_chains', [1, 4, 20])
+@pytest.mark.parametrize('tree_depth', [0, 1, 4, 10])
+def test_build_tree(n_chains, tree_depth):
+    torch.manual_seed(0)
+    
+    event_shape = (4,)
+
+    # n_chains = 20
+    # tree_depth: int = 3
+
+    def neg_log_prob_target(_tensor):
+        return sum_except_batch(_tensor ** 2, event_shape)
+    
+    x0 = torch.randn(size=(n_chains, *event_shape))
+    p0 = torch.randn(size=(n_chains, *event_shape))
+    log_prob_x0 = -neg_log_prob_target(x0)
+    joint0 = log_prob_x0 - _kinetic_energy(p0, event_shape)
+    u_slice = torch.rand(size=(n_chains,)) * torch.exp(joint0)
+
+    # {0, 1} -> {0, 2} -> {-1, 1}
+    v = torch.randint(low=0, high=2, size=(n_chains,)) * 2 - 1
+    step_size = torch.rand(size=(n_chains,)) / 100
+    j = torch.full(size=(n_chains,), fill_value=tree_depth)
+
+    state: ParallelTreeState = _build_tree(
+        x=x0,
+        p=p0,
+        event_shape=event_shape,
+        u_slice=u_slice,
+        v=v,
+        j=j,
+        step_size=step_size,
+        neg_log_prob_target=neg_log_prob_target,
+        log_prob_x=log_prob_x0,
+        max_delta=1000.0
+    )
+
+    assert state.n_chains == n_chains
+    assert state.event_shape == event_shape
+    assert state.x_minus.shape == (n_chains, *event_shape)
+    assert state.x_plus.shape == (n_chains, *event_shape)
+    assert state.p_minus.shape == (n_chains, *event_shape)
+    assert state.p_plus.shape == (n_chains, *event_shape)
+
+    assert state.n_valid.shape == (n_chains,)
+    assert state.sum_accept_prob.shape == (n_chains,)
+    assert state.stop.shape == (n_chains,)
+    assert state.diverged.shape == (n_chains,)
+    assert state.n_leapfrogs.shape == (n_chains,)
+
+    assert torch.isfinite(state.x_minus).all()
+    assert torch.isfinite(state.x_plus).all()
+    assert torch.isfinite(state.p_minus).all()
+    assert torch.isfinite(state.p_plus).all()
+    assert torch.isfinite(state.x_prime).all()
+    assert torch.isfinite(state.log_prob_prime).all()
+
+    assert torch.isfinite(state.n_valid).all()
+    assert torch.isfinite(state.sum_accept_prob).all()
+    assert torch.isfinite(state.stop).all()
+    assert torch.isfinite(state.diverged).all()
+    assert torch.isfinite(state.n_leapfrogs).all()
+
+    assert torch.all(state.x_prime != x0)

--- a/test/test_preconditioned_mcmc.py
+++ b/test/test_preconditioned_mcmc.py
@@ -62,7 +62,8 @@ def test_output_shape_warmup(event_shape,
 
     assert isinstance(samples, Samples)
     assert torch.isfinite(samples.as_tensor()).all()
-    assert samples.as_tensor().shape == (cycle_length * n_cycles, n_chains, *event_shape)
+    assert samples.as_tensor().shape == (
+        cycle_length * n_cycles, n_chains, *event_shape)
     assert samples.as_tensor().dtype == z_initial.dtype
 
 

--- a/test/test_sample_wrapper.py
+++ b/test/test_sample_wrapper.py
@@ -3,7 +3,7 @@ from nfmc.sample import sample
 import torch
 
 
-@pytest.mark.parametrize('kernel', ['rwmh', 'mala', 'hmc'])
+@pytest.mark.parametrize('kernel', ['rwmh', 'mala', 'hmc', 'nuts'])
 @pytest.mark.parametrize('n_chains', [1, 4])
 def test_mcmc(kernel, n_chains):
     event_shape = (2,)
@@ -29,12 +29,15 @@ def test_mcmc(kernel, n_chains):
     'jump_hmc',
     'jump_rwmh',
     'jump_mala',
+    'jump_nuts',
     'neutra_hmc',
     'neutra_rwmh',
     'neutra_mala',
+    'neutra_nuts',
     'ex2_hmc',
     'ex2_rwmh',
     'ex2_mala',
+    'ex2_nuts',
 ])
 @pytest.mark.parametrize('n_chains', [1, 4])
 def test_preconditioned_mcmc(kernel, n_chains):


### PR DESCRIPTION
Add `NUTSKernel` that implements the No-U-turn sampler, which can be used with preconditioners and in kernel compositions. The relevant classes include:
- `nfmc.algorithms.nuts.NUTSKernel`
- `nfmc.algorithms.jump.kernels.NeuTraJumpNUTSKernel`

The `sample` function now supports NUTS via:
```python
sample(..., kernel="nuts")
sample(..., kernel="neutra_nuts")
sample(..., kernel="jump_nuts")
sample(..., kernel="ex2_nuts")
```